### PR TITLE
use btime and rethink example in tutorial 😸 

### DIFF
--- a/docs/src/tutorials/global_identifiability.md
+++ b/docs/src/tutorials/global_identifiability.md
@@ -14,11 +14,12 @@ $\begin{cases}x'(t) = lm - d \, x(t) - \beta \, x(t) \, v(t),\\
     y_1(t) = w(t),\\
     y_2(t) = z(t)\end{cases}$
 
-This model describes HIV dynamics[^1]. Let us run a global identifiability check on this model to get the result with probability of correctness being `p=0.999`. To do this, we will use `assess_identifiability(ode, p)` function.
+This model describes HIV dynamics[^1]. Let us run a global identifiability check on this model to get the result with probability of correctness being `p=0.99`. To do this, we will use `assess_identifiability(ode, p)` function.
 
 Global identifiability needs information about local identifiability first, hence the function we chose here will take care of that extra step for us.
 
 ```@repl
+using BenchmarkTools
 using StructuralIdentifiability
 
 ode = @ODEmodel(
@@ -30,12 +31,13 @@ ode = @ODEmodel(
     y1(t) = w(t),
     y2(t) = z(t)
 )
-@time global_id = assess_identifiability(ode, 0.999)
+@btime global_id = assess_identifiability(ode, 0.99)
 ```
 
-Now let us compare the same system but with probability being `p=0.99`. We will see a reduction in runtime:
+One can play with parameter `p` to obtain greater probability of correctness. For example, let us assess identifiability for the same system with `p=0.9999`
 
 ```@repl
+using BenchmarkTools
 using StructuralIdentifiability
 
 ode = @ODEmodel(
@@ -47,10 +49,8 @@ ode = @ODEmodel(
     y1(t) = w(t),
     y2(t) = z(t)
 )
-@time global_id = assess_identifiability(ode, 0.99)
+@btime global_id = assess_identifiability(ode, 0.9999)
 ```
-
-Indeed, notice how much quicker we obtained the result with 99% correctness guarantee! This illustrates the fact that you may sometimes sacrifice probability slightly to get results much faster.
 
 [^1]:
     > D. Wodarz, M. Nowak, [*Specific therapy regimes could lead to long-term immunological control of HIV*](https://doi.org/10.1073/pnas.96.25.14464), PNAS December 7, 1999 96 (25) 14464-14469;

--- a/docs/src/tutorials/global_identifiability.md
+++ b/docs/src/tutorials/global_identifiability.md
@@ -34,7 +34,7 @@ ode = @ODEmodel(
 @btime global_id = assess_identifiability(ode, 0.99)
 ```
 
-One can play with parameter `p` to obtain greater probability of correctness. For example, let us assess identifiability for the same system with `p=0.9999`
+We also note that it's usually inexpensive to obtain the result with higher probability of correctness. Take, for example, the previous system with `p=0.9999`
 
 ```@repl
 using BenchmarkTools


### PR DESCRIPTION
Hi! It seems most of the execution time in tutorial https://si.sciml.ai/dev/tutorials/global_identifiability/ is spent on compilation, so the comparison is not the most fair one. I suggest using `btime` there.

Moreover, it looks like assessing identifiability doesn't suffer much from probability increase. The following code
```julia
using Logging
global_logger(ConsoleLogger(stderr, Logging.Warn))
using BenchmarkTools
using StructuralIdentifiability

ode = @ODEmodel(
           x'(t) = lm - d * x(t) - beta * x(t) * v(t),
           y'(t) = beta * x(t) * v(t) - a * y(t),
           v'(t) = k * y(t) - u * v(t),
           w'(t) = c * x(t) * y(t) * w(t) - c * q * y(t) * w(t) - b * w(t),
           z'(t) = c * q * y(t) * w(t) - h * z(t),
           y1(t) = w(t),
           y2(t) = z(t)
       )

@btime global_id = assess_identifiability(ode, 0.99)
@btime global_id = assess_identifiability(ode, 0.9999)
```

yields *407 ms* and  *418 ms* on my laptop. Is using small primes for performance actually meaningful?
