### PR TITLE
Fix a bug in PreprocessODE

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,22 @@
+authors = ["Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-authors = ["Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 version = "0.3.7"
+
+[compat]
+AbstractAlgebra = "0.13, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
+BenchmarkTools = "1"
+DataStructures = "0.18"
+GroebnerBasis = "0.1, 0.2, 0.3"
+IterTools = "1"
+MacroTools = "0.5"
+ModelingToolkit = "7, 8"
+Nemo = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29"
+Primes = "0.5"
+Singular = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+SpecialFunctions = "1, 2"
+TestSetExtensions = "2"
+julia = "1.6"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -21,17 +36,5 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
-[compat]
-AbstractAlgebra = "0.13, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
-BenchmarkTools = "1"
-DataStructures = "0.18"
-GroebnerBasis = "0.1, 0.2, 0.3"
-IterTools = "1"
-MacroTools = "0.5"
-ModelingToolkit = "7, 8"
-Nemo = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29"
-Primes = "0.5"
-Singular = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
-SpecialFunctions = "1, 2"
-TestSetExtensions = "2"
-julia = "1.6"
+[extras]
+CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
 authors = ["Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -366,7 +366,11 @@ function PreprocessODE(de::ModelingToolkit.ODESystem, measured_quantities::Array
     out_eqn_dict = Dict{StructuralIdentifiability.Nemo.fmpq_mpoly,Union{StructuralIdentifiability.Nemo.fmpq_mpoly,StructuralIdentifiability.Nemo.Generic.Frac{StructuralIdentifiability.Nemo.fmpq_mpoly}}}()
     
     for i in 1:length(diff_eqs)
-        state_eqn_dict[substitute(state_vars[i], input_symbols.=>gens_)] = eval_at_nemo(diff_eqs[i].rhs, Dict(input_symbols.=>gens_))
+        if !(typeof(diff_eqs[i].rhs) <: Number)
+            state_eqn_dict[substitute(state_vars[i], input_symbols.=>gens_)] = eval_at_nemo(diff_eqs[i].rhs, Dict(input_symbols.=>gens_))
+        else
+            state_eqn_dict[substitute(state_vars[i], input_symbols.=>gens_)] = R(diff_eqs[i].rhs) 
+        end
     end
     for i in 1:length(measured_quantities)
         out_eqn_dict[substitute(y_functions[i], input_symbols.=> gens_)] = eval_at_nemo(measured_quantities[i].rhs, Dict(input_symbols.=>gens_))

--- a/src/util.jl
+++ b/src/util.jl
@@ -302,14 +302,16 @@ function eval_at_nemo(e::Union{ModelingToolkit.Symbolics.Sym,ModelingToolkit.Sym
 end
 
 function eval_at_nemo(e::Union{Integer,Rational}, vals::Dict)
-    return e
+    R = Nemo.parent(first(vals)[2])
+    return Nemo.fmpq_mpoly(R, e)
 end
 
 function eval_at_nemo(e::Union{Float16,Float32,Float64}, vals::Dict)
+    R = Nemo.parent(first(vals)[2])
     if isequal(e % 1, 0)
-        out = Int(e)
+        out = Nemo.fmpq_mpoly(R, Int(e))
     else
-        out = rationalize(e)
+        out = Nemo.fmpq_mpoly(R, rationalize(e))
     end
     @warn "Floating points are not allowed, value $e will be converted to $(out)."
     return out

--- a/src/util.jl
+++ b/src/util.jl
@@ -302,16 +302,14 @@ function eval_at_nemo(e::Union{ModelingToolkit.Symbolics.Sym,ModelingToolkit.Sym
 end
 
 function eval_at_nemo(e::Union{Integer,Rational}, vals::Dict)
-    R = Nemo.parent(first(vals)[2])
-    return Nemo.fmpq_mpoly(R, e)
+    return e
 end
 
 function eval_at_nemo(e::Union{Float16,Float32,Float64}, vals::Dict)
-    R = Nemo.parent(first(vals)[2])
     if isequal(e % 1, 0)
-        out = Nemo.fmpq_mpoly(R, Int(e))
+        out = Int(e)
     else
-        out = Nemo.fmpq_mpoly(R, rationalize(e))
+        out = rationalize(e)
     end
     @warn "Floating points are not allowed, value $e will be converted to $(out)."
     return out

--- a/test/mtk_compat.jl
+++ b/test/mtk_compat.jl
@@ -165,4 +165,19 @@
     correct = Dict(a => :globally, b => :globally, c => :locally)
     to_check = [a, b, c]
     @test isequal(correct, assess_identifiability(de; measured_quantities=measured_quantities, funcs_to_check=to_check))
+    # ----------
+    @parameters a b  
+    @variables t c(t) x1(t) x2(t) y1(t) y2(t)
+    D = Differential(t)
+
+    eqs = [
+        D(x1) ~ -a * x1 + x2 * b / (x1 + b / (c^2 - x2)),
+        D(x2) ~ x2 * c^2 + x1,
+        D(c) ~ 0
+    ]
+    de = ODESystem(eqs, t, name=:Test)
+    measured_quantities = [y1 ~ x2, y2~c]
+    correct = Dict(a => :globally, b => :globally)
+    to_check = [a, b]
+    @test isequal(correct, assess_identifiability(de; measured_quantities=measured_quantities, funcs_to_check=to_check))
 end


### PR DESCRIPTION
Was preventing from running examples like below:
```julia
using StructuralIdentifiability, ModelingToolkit
@parameters k1 k2 eB
@variables t xA(t) xB(t) xC(t) eA(t) eC(t) y1(t) y2(t) y3(t) y4(t)
D = Differential(t)
eqs = [
    D(xA) ~ -k1 * xA,
    D(xB) ~ k1 * xA - k2 * xB,
    D(xC) ~ k2 * xB,
    D(eA) ~ 0,
    D(eC) ~ 0,
]
measured_quantities = [
    y1 ~ xC,
    y2 ~ eA * xA + eB * xB + eC * xC,
    y3 ~ eA,
    y4 ~ eC
]
@named ode = ODESystem(eqs, t)
result = assess_identifiability(ode, measured_quantities=measured_quantities)
```

