### PR TITLE
Switch to groebner

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.7']
         julia-arch: [x64]
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - name: "Checkout"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
 authors = ["Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
-version = "0.3.10"
+version = "0.4.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/benchmarking/benchmark_result.md
+++ b/benchmarking/benchmark_result.md
@@ -1,33 +1,38 @@
-| Model                      | loc_time | glob_time | ioeq_time | wrnsk_time | rank_time | check_time | total   |
-| -------------------------- | -------- | --------- | --------- | ---------- | --------- | ---------- | ------- |
-| Goodwin oscillator         | 0.04     | 0.13      | 0.03      | 0.08       | 0.00      | 0.02       | 0.17    |
-| Akt pathway                | 1.51     | 3.49      | 0.20      | 2.29       | 0.00      | 0.99       | 5.00    |
-| SIWR original              | 0.12     | 17.89     | 3.05      | 9.35       | 0.15      | 5.33       | 18.01   |
-| SEAIJRC Covid model        | 0.08     | 131.24    | 28.61     | 76.67      | 0.76      | 25.20      | 131.33  |
-| MAPK model (6 outputs)     | 14.21    | 25.30     | 2.52      | 11.38      | 0.00      | 11.40      | 39.51   |
-| Pharm                      | 0.04     | 405.70    | 18.42     | 337.13     | 7.22      | 42.94      | 405.74  |
-| SIRS forced                | 0.04     | 30.21     | 0.97      | 27.98      | 0.24      | 1.01       | 30.25   |
-| SIWR with extra output     | 0.13     | 0.54      | 0.16      | 0.23       | 0.00      | 0.14       | 0.67    |
-| CD8 T cell differentiation | 0.36     | 0.44      | 0.02      | 0.11       | 0.00      | 0.31       | 0.80    |
-| HIV                        | 0.09     | 0.49      | 0.37      | 0.08       | 0.00      | 0.04       | 0.57    |
-| MAPK model (5 outputs bis) | 32.81    | 1051.67   | 397.40    | 225.49     | 0.05      | 428.72     | 1084.48 |
-| Chemical reaction network  | 0.05     | 0.46      | 0.07      | 0.34       | 0.00      | 0.05       | 0.52    |
-| Modified LV for testing    | 0.82     | 2.05      | 1.12      | 0.51       | 0.01      | 0.33       | 6.21    |
-| MAPK model (5 outputs)     | 4.91     | 53.24     | 27.59     | 14.73      | 0.00      | 10.92      | 58.16   |
+|Model|loc_time|glob_time|ioeq_time|wrnsk_time|rank_time|check_time|total|
+|-----|---|---|---|---|---|---|---|
+|Goodwin oscillator|0.03|0.09|0.02|0.04|0.00|0.02|0.12|
+|Akt pathway|0.64|4.37|0.18|0.95|0.00|3.23|5.01|
+|SIWR original|0.08|13.08|2.97|2.86|0.14|7.10|13.16|
+|SEAIJRC Covid model|0.07|76.34|27.58|16.23|0.63|31.90|76.41|
+|MAPK model (6 outputs)|4.96|31.59|4.24|10.70|0.00|16.65|36.55|
+|Pharm|0.05|100.86|19.30|39.82|5.64|36.10|100.90|
+|SIRS forced|0.04|8.97|0.89|5.71|0.22|2.14|9.01|
+|SIWR with extra output|0.09|0.67|0.44|0.09|0.00|0.13|0.76|
+|CD8 T cell differentiation|0.48|0.20|0.02|0.09|0.00|0.09|0.69|
+|HIV|0.11|0.41|0.04|0.06|0.00|0.31|0.52|
+|MAPK model (5 outputs bis)|10.33|1665.97|461.87|214.31|0.05|989.75|1676.31|
+|Chemical reaction network|0.04|0.14|0.05|0.05|0.00|0.04|0.18|
+|Modified LV for testing|1.17|2.46|1.50|0.63|0.01|0.24|11.59|
+|MAPK model (5 outputs)|3.91|98.06|59.62|9.97|0.00|28.46|101.97|
 
 *Benchmarking environment:*
 
 * Total RAM (Mb): 16384.0
 * Processor: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
-* Julia version: 1.6.1
+* Julia version: 1.7.2
 
 Versions of the dependencies:
 
-* Primes : 0.5.0
-* Singular : 0.4.6
-* IterTools : 1.3.0
-* GroebnerBasis : 0.3.2
-* AbstractAlgebra : 0.13.6
-* MacroTools : 0.5.6
-* Nemo : 0.20.1
+* Primes : 0.5.2
+* BenchmarkTools : 1.3.1
+* Singular : 0.10.1
+* IterTools : 1.4.0
+* DataStructures : 0.18.11
+* Groebner : 0.2.5
+* ModelingToolkit : 8.9.0
+* AbstractAlgebra : 0.25.3
+* MacroTools : 0.5.9
+* Nemo : 0.30.0
+* Hecke : 0.13.4
+* SpecialFunctions : 2.1.4
 * TestSetExtensions : 2.0.0

--- a/docs/src/tutorials/global_identifiability.md
+++ b/docs/src/tutorials/global_identifiability.md
@@ -35,5 +35,11 @@ global_id = assess_identifiability(ode, 0.99)
 
 We also note that it's usually inexpensive to obtain the result with higher probability of correctness. For example, taking `p=0.9999` in the system above will result only in a slight slowdown.
 
+## Note on the probability of correctness
+
+Currently, the probability of correctness does not include the probability of correctness of the modular reconstruction for Groebner bases. 
+This probability is ensured by additional check modulo a large prime and can be neglected for practical purposes. However, in the future versions, we plan to 
+eliminate this possible error.
+
 [^1]:
     > D. Wodarz, M. Nowak, [*Specific therapy regimes could lead to long-term immunological control of HIV*](https://doi.org/10.1073/pnas.96.25.14464), PNAS December 7, 1999 96 (25) 14464-14469;

--- a/docs/src/utils/global_identifiability.md
+++ b/docs/src/utils/global_identifiability.md
@@ -11,6 +11,5 @@ CurrentModule=StructuralIdentifiability
 StructuralIdentifiability.extract_identifiable_functions
 StructuralIdentifiability.check_field_membership
 StructuralIdentifiability.find_identifiable_functions
-StructuralIdentifiability.simplify_field_generators
 StructuralIdentifiability.get_degree_and_coeffsize
 ```

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -25,11 +25,6 @@ struct ODE{P}
 
         num, den = unpack_fraction(collect(values(x_eqs))[1])
         poly_ring = parent(num)
-        if !all(isascii.(string.(gens(poly_ring))))
-            nonascii_chars = filter(g->!isascii(g), string.(gens(poly_ring)))
-            st = join(nonascii_chars, ", ")
-            @warn "Non-ascii characters are not supported by Singular: " * st
-        end
         x_vars = collect(keys(x_eqs))
         y_vars = collect(keys(y_eqs))
         u_vars = inputs

--- a/test/mtk_compat.jl
+++ b/test/mtk_compat.jl
@@ -62,14 +62,14 @@
     @test isequal(correct, assess_identifiability(de; measured_quantities=measured_quantities, funcs_to_check=funcs_to_check))
 
     # --------------------------------------------------------------------------
-    @parameters mu bi bw a xi gm k
+    @parameters μ bi bw a χ  γ k
     @variables t S(t) I(t) W(t) R(t) y(t)
 
     eqs = [
-        D(S) ~ mu - bi * S * I - bw * S * W - mu * S + a * R,
-        D(I) ~ bw * S * W + bi * S * I - (gm + mu) * I,
-        D(W) ~ xi * (I - W),
-        D(R) ~ gm * I - (mu + a) * R
+        D(S) ~ μ - bi * S * I - bw * S * W - μ * S + a * R,
+        D(I) ~ bw * S * W + bi * S * I - (γ + μ) * I,
+        D(W) ~ χ * (I - W),
+        D(R) ~ γ * I - (μ + a) * R
     ]
     de = ODESystem(eqs, t, name=:TestSIWR)
     measured_quantities = [y ~ k * I]
@@ -77,12 +77,12 @@
     @test isequal(true, all(values(assess_local_identifiability(de; measured_quantities=measured_quantities))))
 
     # check specific parameters
-    funcs_to_check = [mu, bi, bw, a, xi, gm, gm + mu, k, S, I, W, R]
+    funcs_to_check = [μ, bi, bw, a, χ, γ, γ + μ, k, S, I, W, R]
     correct = Dict(f=>true for f in funcs_to_check)
     @test isequal(correct, assess_local_identifiability(de; measured_quantities=measured_quantities, funcs_to_check=funcs_to_check))
 
     # checking ME identifiability
-    funcs_to_check = [mu, bi, bw, a, xi, gm, gm + mu, k]
+    funcs_to_check = [μ, bi, bw, a, χ, γ, γ + μ, k]
     correct = Dict(f=>true for f in funcs_to_check)
     @test isequal((correct, 1), assess_local_identifiability(de;  measured_quantities=measured_quantities, funcs_to_check=funcs_to_check, p=0.99, type=:ME)) 
 


### PR DESCRIPTION
Replacing `GroebnerBasis.jl` and `Singular.jl` with `Groebner.jl`. This resolves issues with Windows, non-ascii characters, and bugs with integer overflow.