### PR TITLE
Compat Helper v3

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,7 +12,7 @@ jobs:
           import Pkg
           name = "CompatHelper"
           uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "2"
+          version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"


### PR DESCRIPTION
CompatHelper has been failing recently, this pr increases the action to v3 (see [here](https://github.com/JuliaRegistries/CompatHelper.jl/blob/d5dc1f4179ab17499619a2d920d07fc3bab353fb/.github/workflows/CompatHelper.yml#L29)).