### PR TITLE
Avoid factoring

### DIFF
--- a/src/elimination.jl
+++ b/src/elimination.jl
@@ -286,7 +286,7 @@ function choose(
         flush(stdout)
         if length(polys) <= 1
             break
-        end 
+        end
     end
     return polys[1]
 end

--- a/src/elimination.jl
+++ b/src/elimination.jl
@@ -280,13 +280,13 @@ function choose(
 ) where {P <: MPolyElem{<:FieldElem}}
     vars = gens(parent(polys[1]))
     for p in generic_point_generator
-        if length(polys) <= 1
-            break
-        end
         # get accounts for the fact that the big ring may contain some auxiliary variables, e.g. rand_proj_var
         point = [get(p, v, zero(base_ring(parent(polys[1])))) for v in vars]
         polys = filter(e -> (evaluate(e, point) == 0), polys)
         flush(stdout)
+        if length(polys) <= 1
+            break
+        end 
     end
     return polys[1]
 end

--- a/src/global_identifiability.jl
+++ b/src/global_identifiability.jl
@@ -77,8 +77,6 @@ function check_field_membership(
     end
 
     eqs = [e for e in eqs if !iszero(e)]
-    @debug "VARS $(vars_ext)"
-    @debug "GB $eqs"
 
     @debug "Computing Groebner basis ($(length(eqs)) equations)"
     flush(stdout)

--- a/src/io_equation.jl
+++ b/src/io_equation.jl
@@ -95,7 +95,9 @@ Output:
 - an extra projection (if `extra_projection` was provided)
 """
 function find_ioprojections(
-    ode::ODE{P}, auto_var_change::Bool, extra_projection=nothing
+    ode::ODE{P},
+    auto_var_change::Bool,
+    extra_projection = nothing,
 ) where {P <: MPolyElem{<:FieldElem}}
     # Initialization
     ring, derivation, x_equations, y_equations, point_generator =
@@ -110,10 +112,12 @@ function find_ioprojections(
 
     if !isnothing(extra_projection)
         extra_projection = parent_ring_change(extra_projection, ring)
-        point_generator = generator_var_change(point_generator, proj_var, extra_projection, one(ring))
+        point_generator =
+            generator_var_change(point_generator, proj_var, extra_projection, one(ring))
         for y in vars(extra_projection)
             coef = derivative(extra_projection, y)
-            y_name, ord = decompose_derivative(var_to_str(y), [var_to_str(v) for v in ode.y_vars])
+            y_name, ord =
+                decompose_derivative(var_to_str(y), [var_to_str(v) for v in ode.y_vars])
             y0 = str_to_var(y_name * "_0", ring)
             # basically a vector of Lie derivtaives of y encoded as equations
             # on the derivtaives over x's, params, and derivatives of u's
@@ -131,7 +135,8 @@ function find_ioprojections(
                 push!(y_ders, (y_new, eq_new))
             end
             y, y_eq = y_ders[end]
-            projection_equation += coef * evaluate(y_eq, [y], [zero(ring)]) // derivative(y_eq, y)
+            projection_equation +=
+                coef * evaluate(y_eq, [y], [zero(ring)]) // derivative(y_eq, y)
         end
         projection_equation, _ = unpack_fraction(projection_equation)
         @debug "Extra projection equation $projection_equation"
@@ -265,7 +270,8 @@ function find_ioprojections(
                         end
                         # change the projection
                         @debug "Change of variables in the extra projection"
-                        projection_equation = make_substitution(projection_equation, x, A * x - B, A)
+                        projection_equation =
+                            make_substitution(projection_equation, x, A * x - B, A)
                         @debug "Change of variables performed"
                         flush(stdout)
                         break
@@ -299,7 +305,12 @@ function find_ioprojections(
             end
         end
         @debug "\t Elimination in the extra projection"
-        projection_equation = eliminate_var(projection_equation, y_equations[y_prolong], var_elim, point_generator)
+        projection_equation = eliminate_var(
+            projection_equation,
+            y_equations[y_prolong],
+            var_elim,
+            point_generator,
+        )
         @debug "\t Elimination in the prolonged equation"
         flush(stdout)
         y_equations[y_prolong] = eliminate_var(
@@ -367,11 +378,13 @@ function find_ioequations(
         @debug "There are several components of the highest dimension, trying to isolate one"
         extra_projection = sum(rand(1:sampling_range) * v for v in keys(io_projections))
         @debug "Extra projections: $extra_projection"
-        new_projections, _, projection_equation = find_ioprojections(ode, auto_var_change, extra_projection)
+        new_projections, _, projection_equation =
+            find_ioprojections(ode, auto_var_change, extra_projection)
         @debug "Check primality"
         if check_primality(io_projections, [projection_equation])
             @debug "Single component of highest dimension isolated, returning"
-            io_projections[str_to_var(PROJECTION_VARNAME, parent(projection_equation))] = projection_equation
+            io_projections[str_to_var(PROJECTION_VARNAME, parent(projection_equation))] =
+                projection_equation
             break
         end
         sampling_range = 2 * sampling_range

--- a/src/primality_check.jl
+++ b/src/primality_check.jl
@@ -7,6 +7,8 @@ function check_primality_zerodim(J::Array{fmpq_mpoly, 1})
     S = Nemo.MatrixSpace(Nemo.QQ, dim, dim)
     matrices = []
 
+    @info "Dim is $dim"
+
     for v in gens(parent(first(J)))
         M = zero(S)
         for (i, vec) in enumerate(basis)

--- a/test/io_projections.jl
+++ b/test/io_projections.jl
@@ -11,16 +11,35 @@
     push!(cases, ode)
 
     #--------------------------------------------------------
-    
+
     # Example from https://github.com/SciML/StructuralIdentifiability.jl/issues/132
     ode = @ODEmodel(
-	    Complex'(t) = 1/C*(((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) - (ke_Complex*Complex(t)*C) - ((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C)),
-	    Complex_2'(t) = 1/C*(((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C) - (ke_Complex_2*Complex_2(t)*C)),
-        Drug'(t) = 1/C*(-(ke_Drug*Drug(t)*C) - ((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) + (45/100*ka*Drug_SC(t))),
-        free_receptor'(t) = 1/C*(-((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) + (66/2500*C) - (kdeg_free_receptor*free_receptor(t)*C) - ((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C)),
-	    Drug_SC'(t) = -(45/100*ka*Drug_SC(t)) - ((1-45/100)*ka*Drug_SC(t)) + u_SC(t),
+        Complex'(t) =
+            1 / C * (
+                ((2 * kon * free_receptor(t) * Drug(t) - koff * Complex(t)) * C) -
+                (ke_Complex * Complex(t) * C) -
+                ((kon_2 * free_receptor(t) * Complex(t) - 2 * koff * Complex_2(t)) * C)
+            ),
+        Complex_2'(t) =
+            1 / C * (
+                ((kon_2 * free_receptor(t) * Complex(t) - 2 * koff * Complex_2(t)) * C) - (ke_Complex_2 * Complex_2(t) * C)
+            ),
+        Drug'(t) =
+            1 / C * (
+                -(ke_Drug * Drug(t) * C) -
+                ((2 * kon * free_receptor(t) * Drug(t) - koff * Complex(t)) * C) +
+                (45 / 100 * ka * Drug_SC(t))
+            ),
+        free_receptor'(t) =
+            1 / C * (
+                -((2 * kon * free_receptor(t) * Drug(t) - koff * Complex(t)) * C) +
+                (66 / 2500 * C) - (kdeg_free_receptor * free_receptor(t) * C) -
+                ((kon_2 * free_receptor(t) * Complex(t) - 2 * koff * Complex_2(t)) * C)
+            ),
+        Drug_SC'(t) =
+            -(45 / 100 * ka * Drug_SC(t)) - ((1 - 45 / 100) * ka * Drug_SC(t)) + u_SC(t),
         y1(t) = Drug(t),
-        y2(t) = free_receptor(t) + Complex(t) + 2*Complex_2(t)
+        y2(t) = free_receptor(t) + Complex(t) + 2 * Complex_2(t)
     )
     push!(cases, ode)
 

--- a/test/io_projections.jl
+++ b/test/io_projections.jl
@@ -1,0 +1,41 @@
+@testset "IO-projections (+ extra projection)" begin
+    cases = []
+
+    # Example from remark 3 in https://arxiv.org/pdf/2111.00991.pdf
+    ode = @ODEmodel(
+        x1'(t) = (1 + x1(t)^2) // 2,
+        x2'(t) = (1 - x1(t)^2) // (1 + x1(t)^2),
+        y1(t) = 2 * x1(t) // (b * (1 + x1(t)^2)),
+        y2(t) = x2(t)
+    )
+    push!(cases, ode)
+
+    #--------------------------------------------------------
+    
+    # Example from https://github.com/SciML/StructuralIdentifiability.jl/issues/132
+    ode = @ODEmodel(
+	    Complex'(t) = 1/C*(((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) - (ke_Complex*Complex(t)*C) - ((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C)),
+	    Complex_2'(t) = 1/C*(((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C) - (ke_Complex_2*Complex_2(t)*C)),
+        Drug'(t) = 1/C*(-(ke_Drug*Drug(t)*C) - ((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) + (45/100*ka*Drug_SC(t))),
+        free_receptor'(t) = 1/C*(-((2*kon*free_receptor(t)*Drug(t)-koff*Complex(t))*C) + (66/2500*C) - (kdeg_free_receptor*free_receptor(t)*C) - ((kon_2*free_receptor(t)*Complex(t)-2*koff*Complex_2(t))*C)),
+	    Drug_SC'(t) = -(45/100*ka*Drug_SC(t)) - ((1-45/100)*ka*Drug_SC(t)) + u_SC(t),
+        y1(t) = Drug(t),
+        y2(t) = free_receptor(t) + Complex(t) + 2*Complex_2(t)
+    )
+    push!(cases, ode)
+
+    #---------------------------------------------------------
+
+    for ode in cases
+        proj, gpg, _ = find_ioprojections(ode, false)
+        for p in values(proj)
+            @test choose([p], gpg) == p
+        end
+        @test !check_primality(proj)
+        # taking simply a sum instead of random linear combination
+        extra_projection = sum(keys(proj))
+        proj, gpg, projection_poly = find_ioprojections(ode, false, extra_projection)
+        @test choose([projection_poly], gpg) == projection_poly
+        @test check_primality(proj, [projection_poly])
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using StructuralIdentifiability:
     check_field_membership,
     check_identifiability,
     check_primality_zerodim,
+    check_primality,
     det_minor_expansion,
     ExpVectTrie,
     get_max_below,
@@ -45,7 +46,9 @@ using StructuralIdentifiability:
     pseudodivision,
     diffreduce,
     io_switch!,
-    add_outputs
+    add_outputs,
+    find_ioprojections,
+    choose
 
 function random_ps(ps_ring, range = 1000)
     result = zero(ps_ring)


### PR DESCRIPTION
New approach for computing an extra projection: instead of using only input-projection for elimination (and running into large factorization), we now pass the random projection as input to the original elimination algorithm (so, elimination is being performed twice, c'est la vie) and its minimal equation is being computed along with the IO-projections from the original system.
The PR is aimed as fixing https://github.com/SciML/StructuralIdentifiability.jl/issues/132