### PR TITLE
Allowing not to give names to the output functions in the MTK format

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -424,10 +424,11 @@ end
 #------------------------------------------------------------------------------
 """
     function preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{ModelingToolkit.Equation})
+    function preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{SymbolicUtils.BasicSymbolic})
 
 Input:
 - `de` - ModelingToolkit.AbstractTimeDependentSystem, a system for identifiability query
-- `measured_quantities` - array of output functions
+- `measured_quantities` - array of output functions (as equations of just functions)
 
 Output:
 - `ODE` object containing required data for identifiability assessment
@@ -437,6 +438,40 @@ Output:
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{ModelingToolkit.Equation},
+)
+    return __preprocess_ode(de, [(replace(string(e.lhs), "(t)" => ""), e.rhs) for e in measured_quantities])
+end
+
+function preprocess_ode(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{<: Symbolics.Num},
+)
+    return __preprocess_ode(de, [("y$i", Symbolics.value(e)) for (i, e) in enumerate(measured_quantities)])
+end
+
+function preprocess_ode(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{<: SymbolicUtils.BasicSymbolic},
+)
+    return __preprocess_ode(de, [("y$i", e) for (i, e) in enumerate(measured_quantities)])
+end
+
+#------------------------------------------------------------------------------
+"""
+    function __preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{Tuple{String, SymbolicUtils.BasicSymbolic}})
+
+Input:
+- `de` - ModelingToolkit.AbstractTimeDependentSystem, a system for identifiability query
+- `measured_quantities` - array of input function in the form (name, expression)
+
+Output:
+- `ODE` object containing required data for identifiability assessment
+- `conversion` dictionary from the symbols in the input MTK model to the variable
+  involved in the produced `ODE` object
+"""
+function __preprocess_ode(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{<: Tuple{String, <: SymbolicUtils.BasicSymbolic}},
 )
     @info "Preproccessing `ModelingToolkit.AbstractTimeDependentSystem` object"
     diff_eqs =
@@ -452,23 +487,25 @@ function preprocess_ode(
         diff_eqs = [SymbolicUtils.substitute(eq, rules) for eq in diff_eqs]
     end
 
-    y_functions = [each.lhs for each in measured_quantities]
+    y_functions = [each[2] for each in measured_quantities]
     inputs = filter(v -> ModelingToolkit.isinput(v), ModelingToolkit.states(de))
     state_vars = filter(
         s -> !(ModelingToolkit.isinput(s) || ModelingToolkit.isoutput(s)),
         ModelingToolkit.states(de),
     )
     params = ModelingToolkit.parameters(de)
-    t = ModelingToolkit.arguments(measured_quantities[1].lhs)[1]
-    params_from_measured_quantities = ModelingToolkit.parameters(
-        ModelingToolkit.ODESystem(measured_quantities, t, name = :DataSeries),
+    t = ModelingToolkit.arguments(diff_eqs[1].lhs)[1]
+    params_from_measured_quantities = union(
+        [filter(s -> !istree(s), get_variables(y[2])) for y in measured_quantities]...
     )
     params = union(params, params_from_measured_quantities)
 
-    input_symbols = vcat(state_vars, y_functions, inputs, params)
-    generators = string.(input_symbols)
+    input_symbols = vcat(state_vars, inputs, params)
+    generators = vcat(string.(input_symbols), [e[1] for e in measured_quantities])
     generators = map(g -> replace(g, "(t)" => ""), generators)
     R, gens_ = Nemo.PolynomialRing(Nemo.QQ, generators)
+    y_vars = [str_to_var(e[1], R) for e in measured_quantities]
+    symb2gens = Dict(input_symbols .=> gens_[1:length(input_symbols)])
     state_eqn_dict = Dict{
         StructuralIdentifiability.Nemo.fmpq_mpoly,
         Union{
@@ -490,19 +527,19 @@ function preprocess_ode(
 
     for i in 1:length(diff_eqs)
         if !(typeof(diff_eqs[i].rhs) <: Number)
-            state_eqn_dict[substitute(state_vars[i], input_symbols .=> gens_)] =
-                eval_at_nemo(diff_eqs[i].rhs, Dict(input_symbols .=> gens_))
+            state_eqn_dict[substitute(state_vars[i], symb2gens)] =
+                eval_at_nemo(diff_eqs[i].rhs, symb2gens)
         else
-            state_eqn_dict[substitute(state_vars[i], input_symbols .=> gens_)] =
+            state_eqn_dict[substitute(state_vars[i], symb2gens)] =
                 R(diff_eqs[i].rhs)
         end
     end
     for i in 1:length(measured_quantities)
-        out_eqn_dict[substitute(y_functions[i], input_symbols .=> gens_)] =
-            eval_at_nemo(measured_quantities[i].rhs, Dict(input_symbols .=> gens_))
+        out_eqn_dict[y_vars[i]] =
+            eval_at_nemo(measured_quantities[i][2], symb2gens)
     end
 
-    inputs_ = [substitute(each, input_symbols .=> gens_) for each in inputs]
+    inputs_ = [substitute(each, symb2gens) for each in inputs]
     if isequal(length(inputs_), 0)
         inputs_ = Vector{StructuralIdentifiability.Nemo.fmpq_mpoly}()
     end
@@ -512,6 +549,6 @@ function preprocess_ode(
             out_eqn_dict,
             inputs_,
         ),
-        Dict(input_symbols .=> gens_),
+        symb2gens,
     )
 end

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -439,19 +439,25 @@ function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{ModelingToolkit.Equation},
 )
-    return __preprocess_ode(de, [(replace(string(e.lhs), "(t)" => ""), e.rhs) for e in measured_quantities])
+    return __preprocess_ode(
+        de,
+        [(replace(string(e.lhs), "(t)" => ""), e.rhs) for e in measured_quantities],
+    )
 end
 
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
-    measured_quantities::Array{<: Symbolics.Num},
+    measured_quantities::Array{<:Symbolics.Num},
 )
-    return __preprocess_ode(de, [("y$i", Symbolics.value(e)) for (i, e) in enumerate(measured_quantities)])
+    return __preprocess_ode(
+        de,
+        [("y$i", Symbolics.value(e)) for (i, e) in enumerate(measured_quantities)],
+    )
 end
 
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
-    measured_quantities::Array{<: SymbolicUtils.BasicSymbolic},
+    measured_quantities::Array{<:SymbolicUtils.BasicSymbolic},
 )
     return __preprocess_ode(de, [("y$i", e) for (i, e) in enumerate(measured_quantities)])
 end
@@ -471,7 +477,7 @@ Output:
 """
 function __preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
-    measured_quantities::Array{<: Tuple{String, <: SymbolicUtils.BasicSymbolic}},
+    measured_quantities::Array{<:Tuple{String, <:SymbolicUtils.BasicSymbolic}},
 )
     @info "Preproccessing `ModelingToolkit.AbstractTimeDependentSystem` object"
     diff_eqs =
@@ -496,7 +502,7 @@ function __preprocess_ode(
     params = ModelingToolkit.parameters(de)
     t = ModelingToolkit.arguments(diff_eqs[1].lhs)[1]
     params_from_measured_quantities = union(
-        [filter(s -> !istree(s), get_variables(y[2])) for y in measured_quantities]...
+        [filter(s -> !istree(s), get_variables(y[2])) for y in measured_quantities]...,
     )
     params = union(params, params_from_measured_quantities)
 
@@ -530,13 +536,11 @@ function __preprocess_ode(
             state_eqn_dict[substitute(state_vars[i], symb2gens)] =
                 eval_at_nemo(diff_eqs[i].rhs, symb2gens)
         else
-            state_eqn_dict[substitute(state_vars[i], symb2gens)] =
-                R(diff_eqs[i].rhs)
+            state_eqn_dict[substitute(state_vars[i], symb2gens)] = R(diff_eqs[i].rhs)
         end
     end
     for i in 1:length(measured_quantities)
-        out_eqn_dict[y_vars[i]] =
-            eval_at_nemo(measured_quantities[i][2], symb2gens)
+        out_eqn_dict[y_vars[i]] = eval_at_nemo(measured_quantities[i][2], symb2gens)
     end
 
     inputs_ = [substitute(each, symb2gens) for each in inputs]

--- a/test/local_identifiability_discrete.jl
+++ b/test/local_identifiability_discrete.jl
@@ -13,6 +13,7 @@
             :dds => sir,
             :res => Dict(S => true, I => true, R => false, α => true, β => true),
             :y => [y ~ I],
+            :y2 => [I],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
@@ -31,6 +32,7 @@
             :dds => eqs,
             :res => Dict(x => true, θ => true),
             :y => [y ~ x],
+            :y2 => [x],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
@@ -49,13 +51,14 @@
             :dds => eqs,
             :res => Dict(x1 => true, x2 => true, θ => false, β => false),
             :y => [y ~ x1],
+            :y2 => [x1],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
     )
 
     @parameters a b c d
-    @variables t x1(t) x2(t) u(t)
+    @variables t x1(t) x2(t) u(t) y2(t)
     D = Difference(t; dt = 1.0)
 
     eqs = [D(x1) ~ a * x1 - b * x1 * x2 + u, D(x2) ~ -c * x2 + d * x1 * x2]
@@ -68,6 +71,7 @@
             :res =>
                 Dict(a => true, b => false, c => true, d => true, x1 => true, x2 => false),
             :y => [y ~ x1],
+            :y2 => [x1],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
@@ -79,6 +83,7 @@
             :dds => lv,
             :res => Dict(b * x2 => true),
             :y => [y ~ x1],
+            :y2 => [x1],
             :known_ic => Array{}[],
             :to_check => [b * x2],
         ),
@@ -90,7 +95,21 @@
             :dds => lv,
             :res =>
                 Dict(a => true, b => true, c => true, d => true, x1 => true, x2 => true),
+            :y => [y ~ x1, y2 ~ x1 / x2],
+            :y2 => [x1, x1 / x2],
+            :known_ic => Array{}[],
+            :to_check => Array{}[],
+        ),
+    )
+
+    push!(
+        cases,
+        Dict(
+            :dds => lv,
+            :res =>
+                Dict(a => true, b => true, c => true, d => true, x1 => true, x2 => true),
             :y => [y ~ x1],
+            :y2 => [x1],
             :known_ic => [x2],
             :to_check => Array{}[],
         ),
@@ -110,6 +129,7 @@
             :dds => abmd1,
             :res => Dict(x1 => true, x2 => true, theta1 => true, theta2 => true),
             :y => [y ~ x1],
+            :y2 => [x1],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
@@ -117,7 +137,7 @@
 
     # Example 2 from https://doi.org/10.1016/j.automatica.2008.03.019
     @parameters theta1 theta2 theta3
-    @variables t x1(t) x2(t) u(t) y(t)
+    @variables t x1(t) x2(t) u(t) y(t) y2(t)
     D = Difference(t; dt = 1.0)
 
     eqs = [D(x1) ~ theta1 * x1^2 + theta2 * x2 + u, D(x2) ~ theta3 * x1]
@@ -135,6 +155,24 @@
                 x2 => false,
             ),
             :y => [y ~ x1],
+            :y2 => [x1],
+            :known_ic => Array{}[],
+            :to_check => Array{}[],
+        ),
+    )
+    push!(
+        cases,
+        Dict(
+            :dds => abmd2,
+            :res => Dict(
+                theta1 => true,
+                theta2 => true,
+                theta3 => true,
+                x1 => true,
+                x2 => true,
+            ),
+            :y => [y ~ x1, y2 ~ x2],
+            :y2 => [x1, x2],
             :known_ic => Array{}[],
             :to_check => Array{}[],
         ),
@@ -144,6 +182,12 @@
         @test assess_local_identifiability(
             c[:dds];
             measured_quantities = c[:y],
+            known_ic = c[:known_ic],
+            funcs_to_check = c[:to_check],
+        ) == c[:res]
+        @test assess_local_identifiability(
+            c[:dds];
+            measured_quantities = c[:y2],
             known_ic = c[:known_ic],
             funcs_to_check = c[:to_check],
         ) == c[:res]

--- a/test/mtk_compat.jl
+++ b/test/mtk_compat.jl
@@ -11,7 +11,10 @@
 
     @test isequal(correct, assess_identifiability(de; measured_quantities = [y1 ~ x0]))
     @test isequal(correct, assess_identifiability(de; measured_quantities = [x0]))
-    @test isequal(correct, assess_identifiability(de; measured_quantities = [(y1 ~ x0).rhs]))
+    @test isequal(
+        correct,
+        assess_identifiability(de; measured_quantities = [(y1 ~ x0).rhs]),
+    )
     # --------------------------------------------------------------------------
     @parameters a01 a21 a12
     @variables t x0(t) x1(t) y1(t) [output = true]

--- a/test/mtk_compat.jl
+++ b/test/mtk_compat.jl
@@ -10,6 +10,8 @@
         Dict(a01 => :nonidentifiable, a21 => :nonidentifiable, a12 => :nonidentifiable)
 
     @test isequal(correct, assess_identifiability(de; measured_quantities = [y1 ~ x0]))
+    @test isequal(correct, assess_identifiability(de; measured_quantities = [x0]))
+    @test isequal(correct, assess_identifiability(de; measured_quantities = [(y1 ~ x0).rhs]))
     # --------------------------------------------------------------------------
     @parameters a01 a21 a12
     @variables t x0(t) x1(t) y1(t) [output = true]


### PR DESCRIPTION
Allowing `assess_identifiability(de; measured_quantities = [x0])` in addition to previously used `assess_identifiability(de; measured_quantities = [y1 ~ x0])`