### PR TITLE
Being more concise in logging

### DIFF
--- a/src/RationalFunctionFields/normalforms.jl
+++ b/src/RationalFunctionFields/normalforms.jl
@@ -295,6 +295,7 @@ function linear_relations_between_normal_forms(
     up_to_degree::Integer;
     seed = 42,
 ) where {T}
+    time_start = time_ns()
     mqs = IdealMQS(fractions_to_dennums(fracs))
     ring = parent(mqs)
     ring_param = ParamPunPam.parent_params(mqs)
@@ -302,10 +303,8 @@ function linear_relations_between_normal_forms(
     nparams = nvars(ring_param)
     finite_field = Nemo.GF(2^30 + 3)
     ParamPunPam.reduce_mod_p!(mqs, finite_field)
-    @info """
-    Computing normal forms (probabilistic)
-    Variables ($nparams in total): $xs_param
-    Up to degree: $up_to_degree
+    @info "Computing normal forms of degree $up_to_degree in $nparams variables"
+    @debug """Variables ($nparams in total): $xs_param
     Modulo: $finite_field"""
     # We first compute relations between the normal forms of linear monomials.
     # Then, we use this knowledge to drop out some monomials of higher degrees.
@@ -390,7 +389,6 @@ function linear_relations_between_normal_forms(
             break
         end
     end
-    @info "Used specialization points: $iters"
     union!(complete_intersection_relations_ff, relations_ff_1)
     @debug "Reconstructing relations to rationals"
     relations_qq = Vector{Generic.Frac{elem_type(ring_param)}}(
@@ -414,5 +412,6 @@ function linear_relations_between_normal_forms(
         )
         relations_qq[i] = relation_qq_param // one(relation_qq_param)
     end
+    @info "Used $iters specializations in $((time_ns() - time_start) / 1e9) seconds, found $(length(complete_intersection_relations_ff)) relations"
     relations_qq
 end

--- a/src/global_identifiability.jl
+++ b/src/global_identifiability.jl
@@ -92,7 +92,7 @@ function initial_identifiable_functions(
     ioeq_time =
         @elapsed io_equations = find_ioequations(ode; var_change_policy = var_change_policy)
     @debug "Sizes: $(map(length, values(io_equations)))"
-    @info "Computed in $ioeq_time seconds" :ioeq_time ioeq_time
+    @info "Computed IO-equations in $ioeq_time seconds"
     _runtime_logger[:ioeq_time] = ioeq_time
 
     if isempty(ode.parameters)
@@ -100,7 +100,7 @@ function initial_identifiable_functions(
     else
         @info "Computing Wronskians"
         wrnsk_time = @elapsed wrnsk = wronskian(io_equations, ode)
-        @info "Computed in $wrnsk_time seconds" :wrnsk_time wrnsk_time
+        @info "Computed Wronskians in $wrnsk_time seconds"
         _runtime_logger[:wrnsk_time] = wrnsk_time
 
         dims = map(ncols, wrnsk)
@@ -109,7 +109,7 @@ function initial_identifiable_functions(
         rank_times = @elapsed wranks = map(rank, wrnsk)
         @debug "Dimensions of the Wronskians $dims"
         @debug "Ranks of the Wronskians $wranks"
-        @info "Ranks of the Wronskians computed in $rank_times seconds" :rank_time rank_times
+        @info "Ranks of the Wronskians computed in $rank_times seconds"
         _runtime_logger[:rank_time] = rank_times
 
         if any([dim != rk + 1 for (dim, rk) in zip(dims, wranks)])


### PR DESCRIPTION
Currently:
```julia
StructuralIdentifiability.assess_identifiability(ode)
[ Info: Assessing local identifiability
[ Info: Local identifiability assessed in 5.2702728 seconds
[ Info: Assessing global identifiability
[ Info: Note: the input model has nontrivial submodels. If the computation for the full model will be too heavy, you may want to try to first analyze one of the submodels. They can be produced using function find_submodels
[ Info: Functions to check involve states
[ Info: Computing IO-equations
┌ Info: Computed in 6.4942927 seconds
│   :ioeq_time = :ioeq_time
└   ioeq_time = 6.4942927
[ Info: Computing Wronskians
┌ Info: Computed in 2.5463854 seconds
│   :wrnsk_time = :wrnsk_time
└   wrnsk_time = 2.5463854
[ Info: Dimensions of the Wronskians [2]
┌ Info: Ranks of the Wronskians computed in 0.0258805 seconds
│   :rank_time = :rank_time
└   rank_times = 0.0258805
[ Info: Simplifying generating set
┌ Info: Computing normal forms (probabilistic)
│ Variables (3 in total): Nemo.QQMPolyRingElem[a, b, c]
│ Up to degree: 2
└ Modulo: Finite field of characteristic 1073741827
[ Info: Used specialization points: 2
[ Info: Computing 4 Groebner bases for block orderings. Simplification code is 1 
┌ Info: Final cleaning and simplification of generators. 
└ Out of 7 fractions 1 are syntactically unique.
[ Info: Checking inclusion with probability 0.991
[ Info: Inclusion checked in 3.9441141 seconds. Result: true
[ Info: Out of 2 initial generators there are 1 indepdendent
[ Info: The ranking of the new set of generators is 1
[ Info: Global identifiability assessed in 52.8739035 seconds
```

This PR:
```julia
StructuralIdentifiability.assess_identifiability(ode)
[ Info: Assessing local identifiability
[ Info: Local identifiability assessed in 0.0036979 seconds
[ Info: Assessing global identifiability
[ Info: Note: the input model has nontrivial submodels. If the computation for the full model will be too heavy, you may want to try to first analyze one of the submodels. They can be produced using function `find_submodels`
[ Info: Functions to check involve states
[ Info: Computing IO-equations
[ Info: Computed IO-equations in 0.003541 seconds
[ Info: Computing Wronskians
[ Info: Computed Wronskians in 0.001314 seconds
[ Info: Dimensions of the Wronskians [2]
[ Info: Ranks of the Wronskians computed in 3.51e-5 seconds
[ Info: Simplifying generating set. Simplification level: standard
[ Info: Computing normal forms of degree 2 in 3 variables
[ Info: Used 2 specializations in 0.0028098 seconds, found 1 relations
[ Info: Computing 4 Groebner bases for degrees (3, 3) for block orderings        
[ Info: Computed Groebner bases in 0.0281257 seconds
[ Info: Inclusion checked with probability 0.991 in 0.0007177 seconds
[ Info: Global identifiability assessed in 0.054335 seconds
```