### PR TITLE
Renaming `preprocess_ode` to `mtk_to_si`

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -574,7 +574,7 @@ function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:Symbolics.Num},
 )
-    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases." 
+    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases."
     return mtk_to_si(de, measured_quantities)
 end
 
@@ -582,7 +582,7 @@ function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:SymbolicUtils.BasicSymbolic},
 )
-    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases." 
+    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases."
     return mtk_to_si(de, measured_quantities)
 end
 

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -520,8 +520,8 @@ end
 
 #------------------------------------------------------------------------------
 """
-    function preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{ModelingToolkit.Equation})
-    function preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{SymbolicUtils.BasicSymbolic})
+    function mtk_to_si(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{ModelingToolkit.Equation})
+    function mtk_to_si(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{SymbolicUtils.BasicSymbolic})
 
 Input:
 - `de` - ModelingToolkit.AbstractTimeDependentSystem, a system for identifiability query
@@ -532,36 +532,63 @@ Output:
 - `conversion` dictionary from the symbols in the input MTK model to the variable
   involved in the produced `ODE` object
 """
+function mtk_to_si(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{ModelingToolkit.Equation},
+)
+    return __mtk_to_si(
+        de,
+        [(replace(string(e.lhs), "(t)" => ""), e.rhs) for e in measured_quantities],
+    )
+end
+
+function mtk_to_si(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{<:Symbolics.Num},
+)
+    return __mtk_to_si(
+        de,
+        [("y$i", Symbolics.value(e)) for (i, e) in enumerate(measured_quantities)],
+    )
+end
+
+function mtk_to_si(
+    de::ModelingToolkit.AbstractTimeDependentSystem,
+    measured_quantities::Array{<:SymbolicUtils.BasicSymbolic},
+)
+    return __mtk_to_si(de, [("y$i", e) for (i, e) in enumerate(measured_quantities)])
+end
+
+#------------------------------------------------------------------------------
+# old name kept for compatibility purposes
+
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{ModelingToolkit.Equation},
 )
-    return __preprocess_ode(
-        de,
-        [(replace(string(e.lhs), "(t)" => ""), e.rhs) for e in measured_quantities],
-    )
+    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases."
+    return mtk_to_si(de, measured_quantities)
 end
 
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:Symbolics.Num},
 )
-    return __preprocess_ode(
-        de,
-        [("y$i", Symbolics.value(e)) for (i, e) in enumerate(measured_quantities)],
-    )
+    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases." 
+    return mtk_to_si(de, measured_quantities)
 end
 
 function preprocess_ode(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:SymbolicUtils.BasicSymbolic},
 )
-    return __preprocess_ode(de, [("y$i", e) for (i, e) in enumerate(measured_quantities)])
+    @warn "Function `preprocess_ode` has been renamed to `mtk_to_si`. The old name can be still used but will disappear in the future releases." 
+    return mtk_to_si(de, measured_quantities)
 end
 
 #------------------------------------------------------------------------------
 """
-    function __preprocess_ode(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{Tuple{String, SymbolicUtils.BasicSymbolic}})
+    function __mtk_to_si(de::ModelingToolkit.AbstractTimeDependentSystem, measured_quantities::Array{Tuple{String, SymbolicUtils.BasicSymbolic}})
 
 Input:
 - `de` - ModelingToolkit.AbstractTimeDependentSystem, a system for identifiability query
@@ -572,7 +599,7 @@ Output:
 - `conversion` dictionary from the symbols in the input MTK model to the variable
   involved in the produced `ODE` object
 """
-function __preprocess_ode(
+function __mtk_to_si(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:Tuple{String, <:SymbolicUtils.BasicSymbolic}},
 )

--- a/src/StructuralIdentifiability.jl
+++ b/src/StructuralIdentifiability.jl
@@ -23,7 +23,7 @@ ParamPunPam.enable_progressbar(false)
 using ModelingToolkit
 
 # defining a model
-export ODE, @ODEmodel, preprocess_ode
+export ODE, @ODEmodel, mtk_to_si
 
 # assessing identifiability
 export assess_local_identifiability, assess_identifiability
@@ -207,7 +207,7 @@ function _assess_identifiability(
         measured_quantities = get_measured_quantities(ode)
     end
 
-    ode, conversion = preprocess_ode(ode, measured_quantities)
+    ode, conversion = mtk_to_si(ode, measured_quantities)
     conversion_back = Dict(v => k for (k, v) in conversion)
     if isempty(funcs_to_check)
         funcs_to_check = [conversion_back[x] for x in [ode.parameters..., ode.x_vars...]]

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -328,7 +328,7 @@ function assess_local_identifiability(
         end
     end
 
-    dds_aux, conversion = preprocess_ode(dds, measured_quantities)
+    dds_aux, conversion = mtk_to_si(dds, measured_quantities)
     if length(funcs_to_check) == 0
         funcs_to_check = vcat(
             parameters(dds),

--- a/src/identifiable_functions.jl
+++ b/src/identifiable_functions.jl
@@ -193,7 +193,7 @@ function _find_identifiable_functions(
     if isempty(measured_quantities)
         measured_quantities = get_measured_quantities(ode)
     end
-    ode, conversion = preprocess_ode(ode, measured_quantities)
+    ode, conversion = mtk_to_si(ode, measured_quantities)
     result = _find_identifiable_functions(
         ode,
         simplify = simplify,

--- a/src/local_identifiability.jl
+++ b/src/local_identifiability.jl
@@ -212,7 +212,7 @@ end
             [e for e in ModelingToolkit.states(ode) if !ModelingToolkit.isoutput(e)],
         )
     end
-    ode, conversion = preprocess_ode(ode, measured_quantities)
+    ode, conversion = mtk_to_si(ode, measured_quantities)
     funcs_to_check_ = [eval_at_nemo(x, conversion) for x in funcs_to_check]
 
     if isequal(type, :SE)


### PR DESCRIPTION
The old name is kept but shows a warning. Addressing #239 