### PR TITLE
trigger warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           GROUP: ${{ matrix.group }}
           JULIA_NUM_THREADS: 11
+        with:
+          depwarn: yes
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
SciML is slowly moving towards erroring on dep warnings during CI.
To be able to achieve this in MTK, I think this package needs to update some of its AbstractAlgebra.jl usage.
https://github.com/SciML/StructuralIdentifiability.jl/actions/runs/7514228707/job/20456867502?pr=264#step:6:1296