### PR TITLE
Fix ModelingTookit extension

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         group:
           - Core
-          - ModelingToolkitExt
+          - ModelingToolkitSIExt
         version:
           - '1'
           - '1.6'

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
-ModelingToolkitExt = ["ModelingToolkit", "SymbolicUtils", "Symbolics"]
+ModelingToolkitSIExt = ["ModelingToolkit", "SymbolicUtils", "Symbolics"]
 
 [compat]
 AbstractAlgebra = "0.34.5, 0.35"

--- a/docs/src/tutorials/creating_ode.md
+++ b/docs/src/tutorials/creating_ode.md
@@ -54,7 +54,7 @@ assess_identifiability(ode)
 
 ## Defining using `ModelingToolkit`
 
-`StructuralIdentifiability` has an extension `ModelingToolkitExt` which allows to use `ODESystem` from `ModelingToolkit` to describe
+`StructuralIdentifiability` has an extension `ModelingToolkitSIExt` which allows to use `ODESystem` from `ModelingToolkit` to describe
 a model. The extension is loaded automatically once `ModelingToolkit` is loaded via `using ModelingToolkit`.
 In this case, one should encode the equations for the states as `ODESystem` and specify the outputs separately.
 In order to do this, we first introduce all functions and scalars:

--- a/docs/src/tutorials/discrete_time.md
+++ b/docs/src/tutorials/discrete_time.md
@@ -87,7 +87,7 @@ assess_local_identifiability(dds; funcs_to_check = [β * S])
 As other main functions in the package, `assess_local_identifiability` accepts an optional parameter `loglevel` (default: `Logging.Info`)
 to adjust the verbosity of logging.
 
-If one loads `ModelingToolkit` (and thus the `ModelingToolkitExt` extension), one can use `DiscreteSystem` from `ModelingToolkit` to
+If one loads `ModelingToolkit` (and thus the `ModelingToolkitSIExt` extension), one can use `DiscreteSystem` from `ModelingToolkit` to
 describe the input model (now in terms of difference!):
 
 ```@example discrete_mtk

--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -1,4 +1,4 @@
-module ModelingToolkitExt
+module ModelingToolkitSIExt
 
 using DataStructures
 using Logging
@@ -14,9 +14,6 @@ if isdefined(Base, :get_extension)
 else
     using ..ModelingToolkit
 end
-
-export mtk_to_si
-export assess_local_identifiability, assess_identifiability, find_identifiable_functions
 
 # ------------------------------------------------------------------------------
 
@@ -96,7 +93,7 @@ Output:
 - `conversion` dictionary from the symbols in the input MTK model to the variable
   involved in the produced `ODE` object
 """
-function mtk_to_si(
+function StructuralIdentifiability.mtk_to_si(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{ModelingToolkit.Equation},
 )
@@ -106,7 +103,7 @@ function mtk_to_si(
     )
 end
 
-function mtk_to_si(
+function StructuralIdentifiability.mtk_to_si(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:Symbolics.Num},
 )
@@ -116,7 +113,7 @@ function mtk_to_si(
     )
 end
 
-function mtk_to_si(
+function StructuralIdentifiability.mtk_to_si(
     de::ModelingToolkit.AbstractTimeDependentSystem,
     measured_quantities::Array{<:SymbolicUtils.BasicSymbolic},
 )

--- a/src/StructuralIdentifiability.jl
+++ b/src/StructuralIdentifiability.jl
@@ -172,4 +172,10 @@ end
 using PrecompileTools
 include("precompile.jl")
 
+### Extensions ###
+
+# ModelingToolkit extension.
+function mtk_to_si end
+export mtk_to_si
+
 end

--- a/test/extensions/modelingtoolkit.jl
+++ b/test/extensions/modelingtoolkit.jl
@@ -662,7 +662,7 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
         # Creates MTK model and assesses its identifiability.
         @parameters r1, r2, c1, c2, beta1, beta2, chi1, chi2
         @variables t, x1(t), x2(t), y(t), u(t)
-        D= Differential(t)
+        D = Differential(t)
         eqs = [
             D(x1) ~ r1 * x1 * (1 - c1 * x1) + beta1 * x1 * x2 / (chi1 + x2) + u,
             D(x2) ~ r2 * x2 * (1 - c2 * x2) + beta2 * x1 * x2 / (chi2 + x1),
@@ -670,9 +670,12 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
         measured_quantities = [y ~ x1]
         ode_mtk = ODESystem(eqs, t, name = :mutualist)
 
-        global_id_1 = assess_identifiability(ode_mtk, measured_quantities = measured_quantities)
-        local_id_1 = assess_local_identifiability(ode_mtk, measured_quantities = measured_quantities)
-        ifs_1 = find_identifiable_functions(ode_mtk, measured_quantities = measured_quantities)
+        global_id_1 =
+            assess_identifiability(ode_mtk, measured_quantities = measured_quantities)
+        local_id_1 =
+            assess_local_identifiability(ode_mtk, measured_quantities = measured_quantities)
+        ifs_1 =
+            find_identifiable_functions(ode_mtk, measured_quantities = measured_quantities)
 
         # Converts mtk model to si model, and assesses its identifiability.
         si_model, _ = mtk_to_si(ode_mtk, measured_quantities)
@@ -683,18 +686,18 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
         # Converts the output dicts from StructuralIdentifiability functions from "weird symbol => stuff" to "symbol => stuff" (the output have some strange meta data which prevents equality checks, this enables this).
         # Structural identifiability also provides variables like x (rather than x(t)). This is a bug, but we have to convert to make it work (now just remove any (t) to make them all equal).
         function sym_dict(dict_in)
-            dict_out = Dict{Symbol,Any}()
+            dict_out = Dict{Symbol, Any}()
             for key in keys(dict_in)
                 sym_key = Symbol(key)
                 sym_key = Symbol(replace(String(sym_key), "(t)" => ""))
                 dict_out[sym_key] = dict_in[key]
-            end    
+            end
             return dict_out
         end
 
         # Checks that the two approaches yields the same result
         @test issetequal(sym_dict(local_id_1), sym_dict(local_id_2))
         @test issetequal(sym_dict(local_id_1), sym_dict(local_id_2))
-        @test length(ifs_1) == length(ifs_2)   
+        @test length(ifs_1) == length(ifs_2)
     end
 end

--- a/test/extensions/modelingtoolkit.jl
+++ b/test/extensions/modelingtoolkit.jl
@@ -658,6 +658,6 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
     end
 
     @testset "Exporting ModelingToolkit Model to SI Model" begin
-
+        # Add test of `mtk_to_si` function here, as well as identifiability functions when applied to its output.
     end
 end

--- a/test/extensions/modelingtoolkit.jl
+++ b/test/extensions/modelingtoolkit.jl
@@ -658,6 +658,43 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
     end
 
     @testset "Exporting ModelingToolkit Model to SI Model" begin
-        # Add test of `mtk_to_si` function here, as well as identifiability functions when applied to its output.
+
+        # Creates MTK model and assesses its identifiability.
+        @parameters r1, r2, c1, c2, beta1, beta2, chi1, chi2
+        @variables t, x1(t), x2(t), y(t), u(t)
+        D= Differential(t)
+        eqs = [
+            D(x1) ~ r1 * x1 * (1 - c1 * x1) + beta1 * x1 * x2 / (chi1 + x2) + u,
+            D(x2) ~ r2 * x2 * (1 - c2 * x2) + beta2 * x1 * x2 / (chi2 + x1),
+        ]
+        measured_quantities = [y ~ x1]
+        ode_mtk = ODESystem(eqs, t, name = :mutualist)
+
+        global_id_1 = assess_identifiability(ode_mtk, measured_quantities = measured_quantities)
+        local_id_1 = assess_local_identifiability(ode_mtk, measured_quantities = measured_quantities)
+        ifs_1 = find_identifiable_functions(ode_mtk, measured_quantities = measured_quantities)
+
+        # Converts mtk model to si model, and assesses its identifiability.
+        si_model, _ = mtk_to_si(ode_mtk, measured_quantities)
+        global_id_2 = assess_identifiability(si_model)
+        local_id_2 = assess_local_identifiability(si_model)
+        ifs_2 = find_identifiable_functions(si_model)
+
+        # Converts the output dicts from StructuralIdentifiability functions from "weird symbol => stuff" to "symbol => stuff" (the output have some strange meta data which prevents equality checks, this enables this).
+        # Structural identifiability also provides variables like x (rather than x(t)). This is a bug, but we have to convert to make it work (now just remove any (t) to make them all equal).
+        function sym_dict(dict_in)
+            dict_out = Dict{Symbol,Any}()
+            for key in keys(dict_in)
+                sym_key = Symbol(key)
+                sym_key = Symbol(replace(String(sym_key), "(t)" => ""))
+                dict_out[sym_key] = dict_in[key]
+            end    
+            return dict_out
+        end
+
+        # Checks that the two approaches yields the same result
+        @test issetequal(sym_dict(local_id_1), sym_dict(local_id_2))
+        @test issetequal(sym_dict(local_id_1), sym_dict(local_id_2))
+        @test length(ifs_1) == length(ifs_2)   
     end
 end

--- a/test/extensions/modelingtoolkit.jl
+++ b/test/extensions/modelingtoolkit.jl
@@ -1,4 +1,4 @@
-if GROUP == "All" || GROUP == "ModelingToolkitExt"
+if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
     @testset "Check identifiability of `ODESystem` object" begin
         using ModelingToolkit
         using ModelingToolkit: parameters
@@ -655,5 +655,9 @@ if GROUP == "All" || GROUP == "ModelingToolkitExt"
                 funcs_to_check = c[:to_check],
             ) == c[:res]
         end
+    end
+
+    @testset "Exporting ModelingToolkit Model to SI Model" begin
+
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,7 +68,7 @@ using StructuralIdentifiability:
 const GROUP = get(ENV, "GROUP", "All")
 
 @static if VERSION >= v"1.10.0"
-    if GROUP == "All" || GROUP == "ModelingToolkitExt"
+    if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
         using Pkg
         Pkg.add("ModelingToolkit")
         Pkg.add("Symbolics")
@@ -123,7 +123,7 @@ function get_test_files(group)
                 if group == "All" ||
                    (group == "Core" && dir != "./extensions") ||
                    (
-                       group == "ModelingToolkitExt" &&
+                       group == "ModelingToolkitSIExt" &&
                        dir == "./extensions" &&
                        VERSION >= v"1.10.0"
                    )


### PR DESCRIPTION
This is an attempt to fix the modelling toolkit extension, and reintroduce support for the `mtk_to_si` function, which was removed in the last update.

Changes:
- `mtk_to_si` is no longer exported from the extension. But instead created in the main package (without methods) and methods then added in the extension.
- I have removed the `export` statements in the extension as these should not be there.
- I have renamed the extension to `ModelingToolkitSIExt`. Motivation: extensions should (ideally) have names unique to both packages involved. If two packages both created extensions called `ModelingToolkitExt` (no unthinkable), these will overwrite each other, causing errors if loaded simultaneously.

Unfortunately this does not work fully. This code:
```julia
using StructuralIdentifiability, ModelingToolkit

@parameters r1, r2, c1, c2, beta1, beta2, chi1, chi2
@variables t, x1(t), x2(t), y(t), u(t)

D= Differential(t)

eqs = [
    D(x1) ~ r1 * x1 * (1 - c1 * x1) + beta1 * x1 * x2 / (chi1 + x2) + u,
    D(x2) ~ r2 * x2 * (1 - c2 * x2) + beta2 * x1 * x2 / (chi2 + x1),
]

measured_quantities = [y ~ x1]

ode_mtk = ODESystem(eqs, t, name = :mutualist)

local_id_1 = assess_identifiability(ode_mtk, measured_quantities = measured_quantities)
global_id_1 = assess_local_identifiability(ode_mtk, measured_quantities = measured_quantities)


si_model = mtk_to_si(ode_mtk, measured_quantities)
global_id_2 = assess_identifiability(si_model)
```
generates a 
```
ERROR: MethodError: no method matching assess_identifiability(::Tuple{ODE{Nemo.QQMPolyRingElem}, Dict{SymbolicUtils.BasicSymbolic{…}, Nemo.QQMPolyRingElem}})

Closest candidates are:
  assess_identifiability(::ODESystem; measured_quantities, funcs_to_check, prob_threshold, loglevel)
   @ ModelingToolkitSIExt ~/.julia/dev/StructuralIdentifiability/ext/ModelingToolkitSIExt.jl:349
  assess_identifiability(::ODE{P}; funcs_to_check, prob_threshold, loglevel) where P<:AbstractAlgebra.MPolyRingElem{Nemo.QQFieldElem}
   @ StructuralIdentifiability ~/.julia/dev/StructuralIdentifiability/src/StructuralIdentifiability.jl:98

Stacktrace:
 [1] top-level scope
   @ ~/Desktop/Julia Playground/Catalyst playground/Environment - Temporary/temproary_playground.jl:24
Some type information was truncated. Use `show(err)` to see complete types.
```
error.

This, however, works:
```julia
ode = @ODEmodel(
    x1'(t) = -(a01 + a21) * x1(t) + a12 * x2(t) + u(t),
    x2'(t) = a21 * x1(t) - a12 * x2(t) - x3(t) / b,
    x3'(t) = x3(t),
    y(t) = x2(t)
)
assess_identifiability(ode)
```