### PR TITLE
Fix issues with unicode names

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -265,7 +265,6 @@ function Base.show(io::IO, ode::ODE)
     for x in ode.x_vars
         if endswith(var_to_str(x), "(t)")
             print(io, chopsuffix(var_to_str(x), "(t)") * "'(t) = ")
-            # print(io, var_to_str(x)[1:(end - 3)] * "'(t) = ")
         else
             print(io, var_to_str(x) * "' = ")
         end

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -264,7 +264,8 @@ end
 function Base.show(io::IO, ode::ODE)
     for x in ode.x_vars
         if endswith(var_to_str(x), "(t)")
-            print(io, var_to_str(x)[1:(end - 3)] * "'(t) = ")
+            print(io, chopsuffix(var_to_str(x), "(t)") * "'(t) = ")
+            # print(io, var_to_str(x)[1:(end - 3)] * "'(t) = ")
         else
             print(io, var_to_str(x) * "' = ")
         end

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -264,7 +264,7 @@ end
 function Base.show(io::IO, ode::ODE)
     for x in ode.x_vars
         if endswith(var_to_str(x), "(t)")
-            print(io, chopsuffix(var_to_str(x), "(t)") * "'(t) = ")
+            print(io, chop(var_to_str(x), tail = 3) * "'(t) = ")
         else
             print(io, var_to_str(x) * "' = ")
         end

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -69,7 +69,7 @@ end
 function Base.show(io::IO, dds::DDS)
     for x in x_vars(dds)
         if endswith(var_to_str(x), "(t)")
-            print(io, var_to_str(x)[1:(end - 3)] * "(t + 1) = ")
+            print(io, chopsuffix(var_to_str(x), "(t)") * "(t + 1) = ")
         else
             print(io, var_to_str(x) * "(t + 1) = ")
         end

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -69,7 +69,7 @@ end
 function Base.show(io::IO, dds::DDS)
     for x in x_vars(dds)
         if endswith(var_to_str(x), "(t)")
-            print(io, chopsuffix(var_to_str(x), "(t)") * "(t + 1) = ")
+            print(io, chop(var_to_str(x), tail = 3) * "(t + 1) = ")
         else
             print(io, var_to_str(x) * "(t + 1) = ")
         end

--- a/src/util.jl
+++ b/src/util.jl
@@ -490,9 +490,9 @@ If yes, returns a pair (a, number), otherwise nothing
 function decompose_derivative(varname::String, prefixes::Array{String})
     for pr in prefixes
         if startswith(varname, pr) && length(varname) > length(pr) + 1
-            if varname[length(pr) + 1] == '_' &&
-               all(map(isdigit, collect(varname[(length(pr) + 2):end])))
-                return (pr, parse(Int, varname[(length(pr) + 2):end]))
+            if varname[nextind(varname, ncodeunits(pr))] == '_' &&
+               all(isdigit, varname[(nextind(varname, ncodeunits(pr)) + 1):end])
+                return (pr, parse(Int, varname[(nextind(varname, ncodeunits(pr)) + 1):end]))
             end
         end
     end

--- a/test/ode.jl
+++ b/test/ode.jl
@@ -17,7 +17,7 @@
     )
 end
 
-@testset "ODE unicode" begin
+@testset "ODE/DDE unicode" begin
     ode = StructuralIdentifiability.@ODEmodel(
         🐁'(t) = a * 🐁 - b * 🐁 * 🦉,
         🦉'(t) = c * 🦉 + d * 🐁 * 🦉,
@@ -44,4 +44,12 @@ end
     StructuralIdentifiability.assess_identifiability(ode)
     StructuralIdentifiability.find_identifiable_functions(ode)
     StructuralIdentifiability.reparametrize_global(ode)
+
+    dde = StructuralIdentifiability.@DDSmodel(
+        🐁(t + 1) = a * 🐁(t) - b * 🐁(t) * 🦉(t),
+        🦉(t + 1) = c * 🦉(t) + d * 🐁(t) * 🦉(t),
+        y(t) = 🐁(t)
+    )
+    println(dde)
+    StructuralIdentifiability.assess_local_identifiability(dde)
 end

--- a/test/ode.jl
+++ b/test/ode.jl
@@ -16,3 +16,32 @@
         y(t) = x1
     )
 end
+
+@testset "ODE unicode" begin
+    ode = StructuralIdentifiability.@ODEmodel(
+        🐁'(t) = a * 🐁 - b * 🐁 * 🦉,
+        🦉'(t) = c * 🦉 + d * 🐁 * 🦉,
+        y(t) = 🐁
+    )
+    println(ode)
+    res = StructuralIdentifiability.assess_identifiability(ode)
+    println(res)
+    @test res == Dict(
+        a => :globally,
+        b => :nonidentifiable,
+        c => :globally,
+        d => :globally,
+        🐁 => :globally,
+        🦉 => :nonidentifiable,
+    )
+
+    ode = StructuralIdentifiability.@ODEmodel(
+        ⬜'(t) = a⬜ * ⬜ * 🐁b🦉c,
+        🐁b🦉c'(t) = 🐁b🦉c,
+        🐁y🐁(t) = ⬜
+    )
+    println(ode)
+    StructuralIdentifiability.assess_identifiability(ode)
+    StructuralIdentifiability.find_identifiable_functions(ode)
+    StructuralIdentifiability.reparametrize_global(ode)
+end


### PR DESCRIPTION
To handle systems like this:

```julia
using StructuralIdentifiability
ode = @ODEmodel(
    🐁'(t) = a * 🐁 - b * 🐁 * 🦉,
    🦉'(t) = c * 🦉 + d * 🐁 * 🦉,
    y(t) = 🐁
)
```
