### PR TITLE
Expression of a function in terms of generators of rational function field (bug fix)

### DIFF
--- a/benchmarking/IdentifiableFunctions/experiments.jl
+++ b/benchmarking/IdentifiableFunctions/experiments.jl
@@ -1128,9 +1128,9 @@ ideal_spec = StructuralIdentifiability.specialize_mod_p(mqs, point)
 
 ord = Groebner.Lex()
 
-hom_ideal_spec = StructuralIdentifiability.homogenize(ideal_spec)
+homogeneous_ideal_spec = StructuralIdentifiability.homogenize(ideal_spec)
 
-Groebner.groebner(hom_ideal_spec, ordering=ord)
+Groebner.groebner(homogeneous_ideal_spec, ordering=ord)
 
 # n = length(vars_shuffled)
 # n1, n2 = div(n, 2), n - div(n, 2)

--- a/benchmarking/IdentifiableFunctions/homogenization.jl
+++ b/benchmarking/IdentifiableFunctions/homogenization.jl
@@ -33,6 +33,6 @@ ideal_spec = StructuralIdentifiability.specialize_mod_p(mqs, point)
 # There is an existent possibility that this would not finish in two and a half lifetimes
 # @time gb = groebner(ideal_spec, ordering = Groebner.Lex(), loglevel = -3);
 
-hom_ideal_spec = StructuralIdentifiability.homogenize(ideal_spec);
+homogeneous_ideal_spec = StructuralIdentifiability.homogenize(ideal_spec);
 # 100 ms
-@time Groebner.groebner(hom_ideal_spec, ordering = Groebner.Lex());
+@time Groebner.groebner(homogeneous_ideal_spec, ordering = Groebner.Lex());

--- a/src/io_equation.jl
+++ b/src/io_equation.jl
@@ -193,7 +193,7 @@ Output:
         for (y, eq) in y_equations
             if y != y_prolong
                 @debug "Eliminating the leader of the equation for $y"
-                # an ugly way of gettin the leader, to replace
+                # an ugly way of getting the leader, to replace
                 next_y_equation = eliminate_var(
                     next_y_equation,
                     eq,

--- a/src/parametrizations.jl
+++ b/src/parametrizations.jl
@@ -17,6 +17,9 @@ function crude_parent_ring_change(poly, new_ring, var_mapping)
     return new_poly
 end
 
+# Reduces the parametric coefficients of a polynomial modulo
+# a Groebner basis of an ideal in the parameter ring.
+# Assumes that there is no division by zero
 function normalize_coefficients(poly, coeff_relations)
     res = zero(parent(poly))
     for (c, m) in zip(coefficients(poly), monomials(poly))

--- a/src/util.jl
+++ b/src/util.jl
@@ -183,7 +183,7 @@ end
 
 function homogenize(fs)
     ring = parent(fs[1])
-    newring, hom_vars = polynomial_ring(
+    newring, homogeneous_vars = polynomial_ring(
         base_ring(ring),
         vcat("X0", map(string, gens(ring))),
         internal_ordering = internal_ordering(ring),
@@ -196,7 +196,8 @@ function homogenize(fs)
             cf = coeff(term, 1)
             ev = monomial(term, 1)
             d = total_degree(ev)
-            new_f += cf * evaluate(ev, hom_vars[2:end]) * hom_vars[1]^(D - d)
+            new_f +=
+                cf * evaluate(ev, homogeneous_vars[2:end]) * homogeneous_vars[1]^(D - d)
         end
         push!(Fs, new_f)
     end

--- a/test/paradigm_shift.jl
+++ b/test/paradigm_shift.jl
@@ -237,6 +237,12 @@ cases = [
             y(t) = x1
         ),
     ),
+    (
+        ode = StructuralIdentifiability.@ODEmodel(
+            x'(t) = b * (x(t)^2 + 1) / (2 * a),
+            y(t) = 2 * x(t) / (b * (1 + x(t)^2))
+        ),
+    ),
 ]
 
 @testset "Global reparametrizations" begin


### PR DESCRIPTION
Alexey Ovchinnikov has reported the failure of an assertion during reparametrization on
```julia
ode = @ODEmodel(
    x'(t) = b * (x(t)^2 + 1) / (2 * a),
    y(t) = 2 * x(t) / (b * (1 + x(t)^2))
)
```
The problem was with computing the expressions of rational function wrt the tag variables, it is fixed.