### PR TITLE
Restrict Julia version to <= 1.10.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3, ≥1.10.4'
+          - '<1.10.3 ≥1.10.4'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3, >1.10.3'
+          - '<1.10.3'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3 ≥1.10.4'
+          - '<1.10.3 || ≥1.10.4'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '1'
+          - '<1.10.3'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3'
+          - '<1.10.3, >1.10.3'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3 || ≥1.10.4'
+          - '<1.10.3 || >=1.10.4'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - Core
           - ModelingToolkitSIExt
         version:
-          - '<1.10.3'
+          - '<1.10.3, ≥1.10.4'
           - '1.6'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '<1.10.3'
+          version: '<1.10.3, >1.10.3'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          version: '<1.10.3'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '<1.10.3, >1.10.3'
+          version: '<1.10.3'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '<1.10.3'
+          version: '<1.10.3 || >=1.10.4'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['<1.10.3, >1.10.4']
+        version: ['<1.10.3']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1']
+        version: ['<1.10.3']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['<1.10.3']
+        version: ['<1.10.3 || >=1.10.4']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['<1.10.3']
+        version: ['<1.10.3, >1.10.4']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '<1.10.3'
+        version: '<1.10.3 || >=1.10.4'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '1'
+        version: '<1.10.3'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '<1.10.3'
+        version: '<1.10.3, >1.10.3'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '<1.10.3, >1.10.3'
+        version: '<1.10.3'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "1.6, 1.7"
+julia = "1.6, 1.7, 1.8, 1.9, 1.10.2"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "<1.10.3, > 1.10.3"
+julia = "<1.10.3, ≥1.10.4"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "<= 1.10.2"
+julia = "<1.10.3"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "1.6, 1.7, 1.8, 1.9, <= 1.10.2"
+julia = "<= 1.10.2"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "1.6, 1.7, 1.8, 1.9, 1.10.2"
+julia = "1.6, 1.7, 1.8, 1.9, <= 1.10.2"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Symbolics = "5.20"
 Test = "1.6, 1.7"
 TestSetExtensions = "2"
 TimerOutputs = "0.5"
-julia = "<1.10.3"
+julia = "<1.10.3, > 1.10.3"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
Current PR makes `StructuralIdentifiability` incompatible with Julia version `1.10.3` (because of a [bug](https://github.com/JuliaLang/julia/issues/54356)) and excludes the version `1.10.3` from CI.