### PR TITLE
doc: make font style coherent

### DIFF
--- a/docs/src/tutorials/discrete_time.md
+++ b/docs/src/tutorials/discrete_time.md
@@ -29,7 +29,7 @@ R(t + 1) = R(t) + \alpha I(t),\\
 y(t) = I(t),
 \end{cases}$
 
-where the observable is `I`, the number of infected people.
+where the observable is $I$, the number of infected people.
 The native way to define such a model in `StructuralIdentifiability` is to use `@DDSmodel` macro which
 uses the shift notation:
 

--- a/docs/src/tutorials/identifiability.md
+++ b/docs/src/tutorials/identifiability.md
@@ -59,7 +59,7 @@ Function `assess_local_identifiability` has several optional parameters
   - `funcs_to_check` a list of specific functions of parameters and states to check identifiability for (see an example below).
     If not provided, the identifiability is assessed for all parameters and states.
 
-  - `prob_threshold` (default $0.99$, i.e. 99%) is the probability of correctness. The algorithm can, in theory, produce wrong result, but the probability that it is correct
+  - `prob_threshold` (default `0.99`, i.e. 99%) is the probability of correctness. The algorithm can, in theory, produce wrong result, but the probability that it is correct
     is guaranteed to be at least `prob_threshold`. However, the probability bounds we use are quite conservative, so the actual probability of correctness is
     likely to be much higher.
   - `type` (default `:SE`). By default, the algorithm checks the standard single-experiment identifiability. If one sets `type = :ME`, then the algorithm
@@ -105,7 +105,7 @@ Similarly to `assess_local_identifiability`, this function has optional paramete
     more involved than for the parameters, so one may want to call the function with `funcs_to_check = ode.parameters` if the
     call `assess_identifiability(ode)` takes too long.
 
-  - `prob_threshold` (default $0.99$, i.e. 99%) is the probability of correctness. Same story as above: the probability estimates are very conservative, so the actual
+  - `prob_threshold` (default `0.99`, i.e. 99%) is the probability of correctness. Same story as above: the probability estimates are very conservative, so the actual
     error probability is much lower than 1%.
     Also, currently, the probability of correctness does not include the probability of correctness of the modular reconstruction for Groebner bases.
     This probability is ensured by an additional check modulo a large prime, and can be neglected for practical purposes.
@@ -128,7 +128,7 @@ can be exchanged. One may wonder how could we guess these functions `beta + delt
 An experimental feature allows to provide an additional keyword argument `known_ic` to inidcate functions of states and parameters for which the
 initial conditions are assumed to be known (while the initial conditions of the system are still assumed to be generic). In this case,
 the identifiability will be assessed for parameters and all the initial conditions or for the initial conditions of `funcs_to_check`.
-Let us add an assumption that the initial conditions `x2(0)` and `x3(0)` are known:
+Let us add an assumption that the initial conditions $x_2(0)$ and $x_3(0)$ are known:
 
 ```@example global
 assess_identifiability(ode, known_ic = [x2, x3])

--- a/docs/src/tutorials/reparametrization.md
+++ b/docs/src/tutorials/reparametrization.md
@@ -30,9 +30,9 @@ R(t)' = \delta(U(t) + I(t)),\\
 y(t) = I(t)
 \end{cases}$
 
-In this model `S` is, as usually, the number of susceptible people, `E` is the number of people exposed to virus but not yet infected
-(as in a simple SEIR model[^1]), and `I` and `U` correspond to number of infected people who report the infection and who do not, respectively.
-We define the model but omit `R` compartment since it does not affect the output dynamics:
+In this model $S$ is, as usually, the number of susceptible people, $E$ is the number of people exposed to virus but not yet infected
+(as in a simple SEIR model[^1]), and $I$ and $U$ correspond to number of infected people who report the infection and who do not, respectively.
+We define the model but omit $R$ compartment since it does not affect the output dynamics:
 
 ```@example seuir
 using StructuralIdentifiability

--- a/src/power_series_utils.jl
+++ b/src/power_series_utils.jl
@@ -36,8 +36,9 @@ end
     ps_matrix_inv(M, prec)
 
 Input:
-- `M` - a square matrix with entries in a univariate power series ring
-      it is assumed that M(0) is invertible and all entries having the same precision
+- `M` - a square matrix with entries in a univariate power series ring it is
+        assumed that `M(0)` is invertible and all entries having the same
+        precision
 - `prec` - an integer, precision, if `-1` then defaults to precision of `M`
 
 Output:
@@ -104,8 +105,8 @@ end
     ps_matrix_log(M)
 
 Input:
-- M - a square matrix with entries in a univariate power series ring
-      it is assumed that `M(0)` is the identity
+- `M` - a square matrix with entries in a univariate power series ring
+        it is assumed that `M(0)` is the identity
 Output:
 - the natural log of `M`
 """
@@ -218,8 +219,9 @@ end
 
 Input:
 - `equations` - a system of the form ``A(x, u, mu)x' - B(x, u, mu) = 0``,
-                where A is a generically nonsingular square matrix. *Assumption*: `A` is nonzero at zero
-- `ic` - initial conditions for x's (dictionary)
+                where ``A`` is a generically nonsingular square matrix.
+                *Assumption*: ``A`` is nonzero at zero
+- `ic` - initial conditions for ``x``'s (dictionary)
 - `inputs` - power series for inputs represented as arrays (dictionary)
 - `prec` - precision of the solution
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -375,7 +375,7 @@ end
 
 Input:
 - `poly` - multivariate polynomial
-- `variables` - a list of variables from the generators of the ring of p
+- `variables` - a list of variables from the generators of the ring of `poly`
 Output:
 - dictionary with keys being tuples of length `length(variables)` and values being polynomials in the variables other than those which are the coefficients at the corresponding monomials (in a smaller polynomial ring)
 """
@@ -486,7 +486,7 @@ end
     decompose_derivative(varname, prefixes)
 
 Determines if it is possible to represent the `varname` as `a_number` where `a` is an element of `prefixes`
-If yes, returns a pair (a, number), otherwise nothing
+If yes, returns a pair `(a, number)`, otherwise nothing
 """
 function decompose_derivative(varname::String, prefixes::Array{String})
     for pr in prefixes

--- a/src/wronskian.jl
+++ b/src/wronskian.jl
@@ -195,7 +195,7 @@ Input:
 Output:
 - a list of Wronskians evaluated at a point modulo prime
 
-Computes the Wronskians of io_equations
+Computes the Wronskians of `io_equations`
 """
 @timeit _to function wronskian(
     io_equations::Dict{P, P},


### PR DESCRIPTION
* Make previously math-styled entities math-styled

* Use code-style where entities should be code-styled

* Fix a typo p -> `poly`