### PR TITLE
ci(dependabot): open dependabot PRs only for major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,9 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
+    ignore:
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Currently, dependabot PRs primarily only update the patch and minor versions of the crates package for checking typos. Restrict this to only major version updates.
