### PR TITLE
Flip functions with states in denominator

### DIFF
--- a/src/identifiable_functions.jl
+++ b/src/identifiable_functions.jl
@@ -124,6 +124,7 @@ function _find_identifiable_functions(
             simplify = simplify,
             rational_interpolator = rational_interpolator,
             priority_variables = [parent_ring_change(p, bring) for p in ode.parameters],
+            want_in_numerator = [parent_ring_change(p, bring) for p in ode.x_vars],
         )
     else
         id_funcs_fracs = dennums_to_fractions(id_funcs)

--- a/src/identifiable_functions.jl
+++ b/src/identifiable_functions.jl
@@ -124,7 +124,7 @@ function _find_identifiable_functions(
             simplify = simplify,
             rational_interpolator = rational_interpolator,
             priority_variables = [parent_ring_change(p, bring) for p in ode.parameters],
-            want_in_numerator = [parent_ring_change(p, bring) for p in ode.x_vars],
+            want_in_numerator = ode.x_vars,
         )
     else
         id_funcs_fracs = dennums_to_fractions(id_funcs)

--- a/src/known_ic.jl
+++ b/src/known_ic.jl
@@ -55,6 +55,7 @@ function _find_identifiable_functions_kic(
         seed = seed,
         simplify = simplify,
         rational_interpolator = rational_interpolator,
+        want_in_numerator = ode.x_vars,
     )
 
     @info "The search for identifiable functions with known initial conditions concluded in $((time_ns() - runtime_start) / 1e9) seconds"


### PR DESCRIPTION
Before:

```julia
using StructuralIdentifiability
ode =  @ODEmodel(
                   x1'(t) = -b * x1(t) + 1 / (c + x4(t)),
                   x2'(t) = alpha * x1(t) - beta * x2(t),
                   x3'(t) = gama * x2(t) - delta * x3(t),
                   x4'(t) = sigma * x4(t) * (gama * x2(t) - delta * x3(t)) / x3(t),
                   y(t) = x1(t)
               )
find_identifiable_functions(ode, with_states=true)
#=
 ...
 (alpha*gama)//x3(t)
 (x2(t)*gama - x3(t)*delta)//x3(t)
=#
```

This PR:

```julia
#=
 ...
 x3(t)//(alpha*gama)
 (x2(t)*gama - x3(t)*delta)//x3(t)
=#
```

I did not run/add tests yet, let us see CI results.
