### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -9,10 +9,7 @@ using StructuralIdentifiability: str_to_var, parent_ring_change, eval_at_dict
 using StructuralIdentifiability: restart_logging, _si_logger, reset_timings, _to
 using TimerOutputs
 
-    using ModelingToolkit
-else
-    using ..ModelingToolkit
-end
+using ModelingToolkit
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks