### PR TITLE
Remove outdated Julia v1.7 version checks

### DIFF
--- a/src/StructuralIdentifiability.jl
+++ b/src/StructuralIdentifiability.jl
@@ -76,11 +76,7 @@ include("known_ic.jl")
 include("input_macro.jl")
 
 function __init__()
-    _si_logger[] = @static if VERSION >= v"1.7.0"
-        Logging.ConsoleLogger(Logging.Info, show_limited = false)
-    else
-        Logging.ConsoleLogger(stderr, Logging.Info)
-    end
+    _si_logger[] = Logging.ConsoleLogger(Logging.Info, show_limited = false)
 end
 
 """

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -25,7 +25,8 @@ const _runtime_logger = Dict(
     :id_npoints_normalform => 0,
 )
 
-const _si_logger = Ref{Logging.ConsoleLogger}(Logging.ConsoleLogger(Logging.Info, show_limited = false))
+const _si_logger =
+    Ref{Logging.ConsoleLogger}(Logging.ConsoleLogger(Logging.Info, show_limited = false))
 
 function restart_logging(; loglevel = Logging.Info)
     @assert loglevel isa Base.CoreLogging.LogLevel

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -25,19 +25,11 @@ const _runtime_logger = Dict(
     :id_npoints_normalform => 0,
 )
 
-const _si_logger = @static if VERSION >= v"1.7.0"
-    Ref{Logging.ConsoleLogger}(Logging.ConsoleLogger(Logging.Info, show_limited = false))
-else
-    Ref{Logging.ConsoleLogger}(Logging.ConsoleLogger(stderr, Logging.Info))
-end
+const _si_logger = Ref{Logging.ConsoleLogger}(Logging.ConsoleLogger(Logging.Info, show_limited = false))
 
 function restart_logging(; loglevel = Logging.Info)
     @assert loglevel isa Base.CoreLogging.LogLevel
-    _si_logger[] = @static if VERSION >= v"1.7.0"
-        Logging.ConsoleLogger(loglevel, show_limited = false)
-    else
-        Logging.ConsoleLogger(stderr, loglevel)
-    end
+    _si_logger[] = Logging.ConsoleLogger(loglevel, show_limited = false)
     for r in _runtime_rubrics
         _runtime_logger[r] = 0
     end


### PR DESCRIPTION
## Summary
Since Julia v1.10 is now the LTS, version checks for v1.7 are no longer needed.

## Changes
- Removed v1.7 check in __init__ function (src/StructuralIdentifiability.jl)
- Removed v1.7 checks in logging initialization (src/logging.jl)
- Now always uses ConsoleLogger with show_limited = false

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)