### PR TITLE
Update CI to test on Julia 1, lts, and pre versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,8 @@ jobs:
           - ModelingToolkitSIExt
         version:
           - '1'
-          - '1.10'
+          - 'lts'
+          - 'pre'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary
- Replace specific Julia version '1.10' with 'lts' in CI matrix
- Maintains testing on Julia 1, lts, and pre versions
- Aligns with SciML ecosystem standards for comprehensive version testing

## Test plan
- [x] Validate YAML syntax
- [ ] Verify CI passes on all Julia versions after merge

🤖 Generated with [Claude Code](https://claude.ai/code)