### PR TITLE
retaining original generators for the final casting

### DIFF
--- a/src/RationalFunctionFields/RationalFunctionField.jl
+++ b/src/RationalFunctionFields/RationalFunctionField.jl
@@ -774,6 +774,8 @@ Result is correct (in the Monte-Carlo sense) with probability at least `prob_thr
     for (ord, rff_gens) in fan
         append!(new_fracs, rff_gens)
     end
+    # retaining the original generators
+    append!(new_fracs, generators(rff))
     new_fracs_unique = unique(new_fracs)
     @debug """
 Final cleaning and simplification of generators. 

--- a/test/RationalFunctionFields/simplification.jl
+++ b/test/RationalFunctionFields/simplification.jl
@@ -1,0 +1,49 @@
+@testset "RationalFunctionField: membership" begin
+    cases = []
+
+    R, (x, y, z) = Nemo.polynomial_ring(Nemo.QQ, ["x", "y", "z"])
+
+    push!(
+        cases,
+        Dict(
+            :field => RationalFunctionField([x + y // one(R), (x^2 + y^2) // (x + y)]),
+            :correct => Set([x + y // one(R), x * y // one(R)]),
+        ),
+    )
+
+    # this does not pass as it finds a fraction with lower degree but many terms, maybe this one should be considered simpler
+    # push!(
+    #    cases,
+    #    Dict(
+    #        :field => RationalFunctionField([
+    #            x + y // one(R),
+    #            x^10 // y^10,
+    #        ]),
+    #        :correct => Set([x + y // one(R), x^10 // y^10]),
+    #    ),
+    #)
+
+    R, (x, y, z, u, v) = Nemo.polynomial_ring(Nemo.QQ, ["x", "y", "z", "u", "v"])
+
+    push!(
+        cases,
+        Dict(
+            :field =>
+                RationalFunctionField([x^i + y^i + z^i + u^i + v^i // one(R) for i in 1:5]),
+            :correct => Set([
+                x + y + z + u + v // one(R),
+                x^2 + y^2 + z^2 + u^2 + v^2 // one(R),
+                x^3 + y^3 + z^3 + u^3 + v^3 // one(R),
+                y * z * u * v +
+                x * z * u * v +
+                x * y * u * v +
+                x * y * z * (u + v) // one(R),
+                x * y * z * u * v // one(R),
+            ]),
+        ),
+    )
+
+    for c in cases
+        @test Set(simplified_generating_set(c[:field])) == c[:correct]
+    end
+end

--- a/test/identifiable_functions.jl
+++ b/test/identifiable_functions.jl
@@ -224,17 +224,7 @@ ode = StructuralIdentifiability.@ODEmodel(
     Q'(t) = -e * In(t) * g + In(t) * g - s * Q(t),
     y(t) = In(t) * Ninv
 )
-ident_funcs = [
-    (a + e * s - s) // (a * e),
-    b,
-    a + g,
-    (
-        a^2 * e * s + a^2 * g + 3 * a * e * g * s - a * e * s^2 - 2 * a * g * s +
-        e^2 * g * s^2 - 2 * e * g * s^2 + g * s^2
-    ) // (a + e * s - s),
-    s,
-    Ninv,
-]
+ident_funcs = [(a + e * s - s) // (a * e), b, a + g, a*b*g + a*b*s + b*e*g*s, s, Ninv]
 push!(test_cases, (ode = ode, ident_funcs = ident_funcs))
 
 # St.
@@ -830,6 +820,8 @@ ident_funcs = [a, b * c, x * c]
 push!(test_cases, (ode = ode, with_states = true, ident_funcs = ident_funcs))
 
 # llw1987 model
+# also contains (p2 * x2 - p4 * x1) // (p3 - p1)
+# which shows up if the original generators are not added
 ode = StructuralIdentifiability.@ODEmodel(
     x1'(t) = -p1 * x1(t) + p2 * u(t),
     x2'(t) = -p3 * x2(t) + p4 * u(t),
@@ -843,7 +835,7 @@ ident_funcs = [
     p2 * p4 // one(x1),
     (p3 + p1) // one(x1),
     (p2 * x2 + p4 * x1) // one(x1),
-    (p2 * x2 - p4 * x1) // (p3 - p1),
+    x1 * p1 * p4 + x2 * p2 * p3,
 ]
 push!(test_cases, (ode = ode, with_states = true, ident_funcs = ident_funcs))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,8 @@ using StructuralIdentifiability:
     quotient_basis,
     rational_function_cmp,
     update_trbasis_info!,
-    poly_ring
+    poly_ring,
+    simplified_generating_set
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
Gives better simplification, e.g., for SLIQR