### PR TITLE
More explicit and informative error message for non-rational models

### DIFF
--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -6,7 +6,8 @@ using Nemo
 using Random
 using StructuralIdentifiability
 using StructuralIdentifiability: str_to_var, parent_ring_change, eval_at_dict
-using StructuralIdentifiability: restart_logging, _si_logger, reset_timings, _to, nonrational_error
+using StructuralIdentifiability:
+    restart_logging, _si_logger, reset_timings, _to, nonrational_error
 using TimerOutputs
 
 using ModelingToolkit
@@ -49,7 +50,11 @@ function StructuralIdentifiability.eval_at_nemo(e::SymbolicUtils.BasicSymbolic, 
         elseif startswith(String(Symbol(Symbolics.operation(e))), "Shift")
             return args[1]
         end
-        throw(nonrational_error("operator $(Symbolics.operation(e)) is not an arithmetic one"))
+        throw(
+            nonrational_error(
+                "operator $(Symbolics.operation(e)) is not an arithmetic one",
+            ),
+        )
     elseif e isa Symbolics.Symbolic
         return get(vals, e, e)
     end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -98,12 +98,14 @@ function print_timings_table()
 end
 
 function nonrational_error(precision::String)
-    return Base.ArgumentError("""
+    return Base.ArgumentError(
+        """
 The system does not seem to have rational (polynomial divided by polynomial) right-hand side.
 More precisely: $precision.
 For the moment, such systems cannot be handled directly. We advise to try a variable transformation,
 for an example and some guidelines, we refer to pages 4-5 of https://doi.org/10.3390/v17040496
 (in particular the discussion after Proposition 1). Further examples of transformations can be found
 in Sections A.2 and A.3 of the Supplementary Material of https://doi.org/10.1093/bioinformatics/bty1069
-""")
+""",
+    )
 end


### PR DESCRIPTION
This PR aims at addressing #417 
Now, the following errors are shown:

* For `D(x1) ~ exp(x1)`:
```
ERROR: LoadError: ArgumentError: The system does not seem to have rational (polynomial divided by polynomial) right-hand side.
More precisely: operator exp is not an arithmetic one.
```
* For `D(x1) ~ x1^r1`:
```
ERROR: LoadError: ArgumentError: The system does not seem to have rational (polynomial divided by polynomial) right-hand side.
More precisely: non-integer exponent r1.
```
* For `ode = @ODEmodel(x'(t) = a * exp(x(t)), y(t) = x(t))`
```
ERROR: LoadError: ArgumentError: The system does not seem to have rational (polynomial divided by polynomial) right-hand side.
More precisely: function exp is nonarithmetic one.
```
* For `ode = @ODEmodel(x'(t) = x(t) + b^a, y(t) = x(t))`
```
ERROR: LoadError: ArgumentError: The system does not seem to have rational (polynomial divided by polynomial) right-hand side.
More precisely: noninteger exponent a.
```