### PR TITLE
Treating `missing` in MTK bindings

### DIFF
--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -271,7 +271,7 @@ function __mtk_to_si(
     if (length(observed(de)) > 0) || (length(bindings(de)) > 0)
         rules = Dict(s.lhs => s.rhs for s in observed(de))
         for (k, v) in bindings(de)
-            if ModelingToolkitBase.isparameter(k)
+            if ModelingToolkitBase.isparameter(k) && Symbolics.value(v) !== missing
                 rules = merge(rules, Dict(scalarize(k) .=> scalarize(v)))
             end
         end

--- a/test/extensions/modelingtoolkit.jl
+++ b/test/extensions/modelingtoolkit.jl
@@ -851,7 +851,8 @@ if GROUP == "All" || GROUP == "ModelingToolkitSIExt"
             y ~ q .* x,
         ]
 
-        @mtkcompile sys = System(eqs, t; bindings = [y => x, q => 2 .* p])
+        # Missing binding added as a test for https://github.com/SciML/StructuralIdentifiability.jl/issues/507
+        @mtkcompile sys = System(eqs, t; bindings = [y => x, q => 2 .* p, p => missing])
 
         res = mtk_to_si(sys, Equation[])
 


### PR DESCRIPTION
A fix for #507 (thanks to @AayushSabharwal  for suggestion)