### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,34 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - "Core"
-          - "QA"
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
-    secrets: "inherit"
-
-  tests-extensions:
-    name: "Tests Extensions"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - "ModelingToolkitSIExt"
-        version:
-          - "1"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,8 @@
+[Core]
+versions = ["1", "lts", "pre"]
+
+[QA]
+versions = ["1", "lts", "pre"]
+
+[ModelingToolkitSIExt]
+versions = ["1"]


### PR DESCRIPTION
## Summary

Converts the root `Tests.yml` workflow to the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the package's own group × version test matrix declared once in a root `test/test_groups.toml`.

### What changed
- `.github/workflows/Tests.yml`: the two hand-maintained matrix jobs (`tests` and `tests-extensions`) are replaced by a single thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  The `name: "Tests"`, `on:` triggers, and `concurrency:` block are preserved verbatim so the branch-protection status check is unaffected.
- `test/test_groups.toml` (new): declares the matrix
  ```toml
  [Core]
  versions = ["1", "lts", "pre"]

  [QA]
  versions = ["1", "lts", "pre"]

  [ModelingToolkitSIExt]
  versions = ["1"]
  ```

No `with:` inputs are needed: `runtests.jl` already dispatches on the standard `GROUP` env var (default `GROUP`), coverage/check-bounds/coverage-directories all match the workflow defaults, and there are no apt packages. Linux-only, so no `os` field is added (default `ubuntu-latest`).

### Matrix match
Ran `compute_affected_sublibraries.jl <root> --root-matrix` against the new TOML and compared to the old workflow's matrix:

Old workflow cells (group, version): `(Core,1) (Core,lts) (Core,pre) (QA,1) (QA,lts) (QA,pre) (ModelingToolkitSIExt,1)` — 7 cells.

Computed cells: identical 7 cells, all `runner=ubuntu-latest`, `continue_on_error=false`.

**Matrix match: 7/7 exact.**

### QA
Category A: `runtests.jl` already has Core/QA GROUP dispatch and a `QA` group, so no harness change and no local Aqua run is needed — static matrix verification only. `test/test_groups.toml` parses as TOML and `Tests.yml` parses as YAML. The `[compat]` julia floor is already `1.10.4, 1.11.2` (LTS covered), so no metadata changes were required. All other workflow files (Downgrade, Documentation, FormatCheck, SpellCheck, PerformanceCheck, TagBot, etc.) are left untouched.

---
Ignore until reviewed by @ChrisRackauckas.