### PR TITLE
QA: normalize versions to [lts,1] (drop pre)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,7 +2,7 @@
 versions = ["1", "lts", "pre"]
 
 [QA]
-versions = ["1", "lts", "pre"]
+versions = ["lts", "1"]
 
 [ModelingToolkitSIExt]
 versions = ["1"]


### PR DESCRIPTION
Normalizes the ROOT `test/test_groups.toml` `[QA]` group's `versions` to the canonical set.

- `[QA].versions`: `["1", "lts", "pre"]` -> `["lts", "1"]`

Rationale: Aqua/JET QA checks should run on the LTS Julia (1.10) plus the latest stable release (`1`), and should never run on the prerelease channel (`pre`). Prerelease churn in QA tooling produces noisy failures that are not actionable. This matches the canonical QA convention used across the SciML fleet.

Only the `[QA]` group's `versions` line is changed; `[Core]` and `[ModelingToolkitSIExt]` are untouched.

The repo's Julia compat floor is `1.10.4, 1.11.2` (LTS series), so no floor exception applies and the canonical `["lts", "1"]` is correct.

Ignore until reviewed by @ChrisRackauckas.