### PR TITLE
Fix false-positive in check_primality on degenerate random specialization

### DIFF
--- a/src/primality_check.jl
+++ b/src/primality_check.jl
@@ -61,10 +61,35 @@ function check_primality(
     ring = parent(leaders[1])
 
     Rspec, vspec = Nemo.polynomial_ring(Nemo.QQ, [var_to_str(l) for l in leaders])
-    eval_point = [v in keys(polys) ? v : ring(rand(1:100)) for v in gens(ring)]
-    all_polys = vcat(collect(values(polys)), extra_relations)
-    zerodim_ideal =
-        collect(map(p -> parent_ring_change(evaluate(p, eval_point), Rspec), all_polys))
+    # Generic degree of each generator in its leader. Specializing the other
+    # variables must preserve these degrees; the ideal is considered on the
+    # open set where the leading coefficients (w.r.t. the leaders) do not
+    # vanish, so a specialization that drops a degree corresponds to leaving
+    # that set and would collapse the quotient ring, yielding a spurious result.
+    leader_degrees = Dict(l => Nemo.degree(p, l) for (l, p) in polys)
+
+    local zerodim_ideal
+    attempts = 0
+    while true
+        attempts += 1
+        eval_point = [v in keys(polys) ? v : ring(rand(1:100)) for v in gens(ring)]
+        specialized = Dict(l => evaluate(polys[l], eval_point) for l in leaders)
+        if all(Nemo.degree(specialized[l], l) == leader_degrees[l] for l in leaders)
+            all_polys = vcat(
+                [specialized[l] for l in leaders],
+                [evaluate(p, eval_point) for p in extra_relations],
+            )
+            zerodim_ideal =
+                collect(map(p -> parent_ring_change(p, Rspec), all_polys))
+            break
+        end
+        if attempts >= 100
+            error(
+                "Failed to find a generic specialization for the primality check " *
+                    "after $attempts attempts (the leading coefficients keep vanishing).",
+            )
+        end
+    end
 
     return check_primality_zerodim(zerodim_ideal)
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

The master `tests / Core (julia pre, ubuntu-latest)` lane is red. The only failure is `test/bodies/io_projections.jl:55`:

```
IO-projections (+ extra projection): Test Failed at .../test/bodies/io_projections.jl:55
  Expression: !(check_primality(proj))
   Evaluated: !(check_primality(Dict(...)))   # check_primality returned true
```

The `proj` ideal for the issue-#132 PK/PD model is **not** prime, so the test asserts `!check_primality(proj)`. The function returned `true`, failing the test. This is the prerelease (Julia 1.13.0-rc1) lane only; 1.10/1.11/1.12 pass.

## Root cause (a real soundness bug, not version-specific)

`check_primality(polys, extra_relations)` specializes every non-leader variable of each generator to a random integer (`rand(1:100)`), then asks whether the characteristic polynomial of a generic multiplication operator on the resulting zero-dimensional quotient is irreducible.

Each generator here is degree 2 in its leader (`y1(t)_2`, `y2(t)_3`), with a non-constant leading coefficient in the other variables. When the random point makes a leading coefficient vanish, the generator drops to degree 1. When all generators collapse to degree 1, the quotient ring becomes **1-dimensional**, its charpoly is degree 1 (trivially irreducible), and the routine reports the (non-prime) ideal as prime — a false positive.

Reproduced on 1.13.0-rc1: over seeds `0..499`, `check_primality(proj)` returns `true` for 6 of them (e.g. 30, 169, 305, 393, 488, 496). The 1.13 RNG stream change merely caused the un-seeded global RNG to land on such a draw by the time the test reached line 55; the bug is RNG-dependent and present on every version.

For a bad seed the Groebner basis specializes to `[y1(t)_2 - c1, y2(t)_3 - c2]` (quotient dim 1, irreducible degree-1 charpoly → `true`); for a good seed it is `[y1(t)_2^2 + ..., y2(t)_3^2 + ...]` (quotient dim 4, charpoly factors → `false`).

## Fix

Only accept random specializations that **preserve each generator's degree in its leader** — i.e. stay on the open set where the leading coefficients do not vanish (precisely the set the ideal is "saturated at the leading coefficient", per the docstring). Resample otherwise, with a bounded retry. `extra_relations` are evaluated at the same point, unchanged behavior.

## Verification (run locally)

Julia 1.13.0-rc1:
- false-positive rate over seeds `0..499`: **6/500 → 0/500**
- `io_projections` body: **10/10** (was 9 pass / 1 fail)
- positive case `check_primality(proj, [projection_poly])`: **50/50 true** (unchanged)
- negative case stress over seeds `0..299`: **0/300 true** (correct)

Julia 1.12 (no regression):
- `io_projections` body: 10/10
- `check_primality_zerodim` body: 5/5 (subroutine untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)