### PR TITLE
Bump version to 0.5.24

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-version = "0.5.23"
+version = "0.5.24"
 authors = ["Alexander Demin, Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.5.23 -> 0.5.24) to release unreleased commits on `master` via JuliaRegistrator.