### PR TITLE
Release prep: bump StructuralIdentifiability to 0.5.25

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-version = "0.5.24"
+version = "0.5.25"
 authors = ["Alexander Demin, Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 
 [deps]


### PR DESCRIPTION
Patch release to register the accumulated docstring/QA/test scaffolding changes (mtk_to_si/eval_at_nemo docstrings, SciMLTesting QA config update, test Project.toml cleanup) since 0.5.24.