### PR TITLE
Drop TestSetExtensions 2 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,7 +54,7 @@ SpecialFunctions = "2"
 SymbolicUtils = "4"
 Symbolics = "7"
 Test = "1.10, 1.11"
-TestSetExtensions = "2, 3, 4"
+TestSetExtensions = "3, 4"
 TimerOutputs = "0.5.10"
 julia = "1.10.4, 1.11.2"
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- remove the stale TestSetExtensions 2 compatibility line from the test target
- retain TestSetExtensions 3 while version 4 remains a recent transition

This is a test-dependency metadata change; package source and public API are unchanged.

## Local verification

- Julia 1.10.11 canonical direct-dependency floor resolution: TestSetExtensions 3.0.0, AbstractAlgebra 0.42.0, Nemo 0.46.0, SciMLTesting 2.1.0
- locked exact-floor `GROUP=Core`: passed every Core file; the final `Core/y_saturation.jl` summary was 8/8
- Julia 1.12.6 current graph: TestSetExtensions 4.0.3, AbstractAlgebra 0.48.6, Nemo 0.54.2, SciMLTesting 2.2.0
- current-graph `GROUP=Core Pkg.test()`: passed
- current-graph `GROUP=QA Pkg.test()`: 18 passed, 1 pre-existing broken, 19 total
- Runic 1.7.0 `--check .`: passed
- `git diff --check` and exact compat assertion: passed

The Julia 1.10 floor test used a locked test environment and invoked the repository's unchanged SciMLTesting `Core` group directly. This avoids Julia 1.10's old-style test-sandbox re-resolution replacing TestSetExtensions 3 with a newer release.

The existing Core and QA suites cover this metadata-only change; no test was skipped, disabled, silenced, or loosened.
