### PR TITLE
Avoid ambiguous generators in output saturation

### DIFF
--- a/src/output_saturation.jl
+++ b/src/output_saturation.jl
@@ -20,15 +20,22 @@ function saturate_outputs(
     lie_ders = lie_derivatives_up_to(ode, Dict(ode.y_equations[y] => ord for (y, ord) in orders))
     @info "Degrees: $([(total_degree(numerator(f)), total_degree(denominator(f))) for f in lie_ders])"
 
-    current_y = RationalFunctionField(vcat(collect(values(ode.y_equations)), ode.u_vars, ode.parameters))
+    current_generators = [
+        f // 1 for
+            f in vcat(collect(values(ode.y_equations)), ode.u_vars, ode.parameters)
+    ]
+    current_y = RationalFunctionField(current_generators)
     lie_ders = filter(f -> total_degree_frac(f) <= max_deg, lie_ders)
     sort!(lie_ders, lt = RationalFunctionFields.rational_function_cmp)
     for f in lie_ders
         if !first(RationalFunctionFields.check_algebraicity_modp(current_y, [f]))
-            current_y = RationalFunctionField(vcat(generators(current_y), [f]))
+            push!(current_generators, f)
+            current_y = RationalFunctionField(current_generators)
         end
     end
-    new_outputs = generators(current_y)[(length(ode.y_vars) + length(ode.u_vars) + length(ode.parameters) + 1):end]
+    new_outputs = current_generators[
+        (length(ode.y_vars) + length(ode.u_vars) + length(ode.parameters) + 1):end,
+    ]
 
     idx = 1
     old_y_names = map(var_to_str, ode.y_vars)

--- a/test/bodies/y_saturation.jl
+++ b/test/bodies/y_saturation.jl
@@ -2,6 +2,17 @@ include(joinpath(@__DIR__, "..", "shared", "test_setup.jl"))
 
 if GROUP == "All" || GROUP == "Core"
     @testset "Output saturation" begin
+        independent_derivative = @ODEmodel(
+            x'(t) = z(t),
+            z'(t) = 0,
+            y(t) = x(t) // a
+        )
+        saturated = saturate_outputs(
+            independent_derivative,
+            Dict(only(independent_derivative.y_vars) => 1),
+        )
+        @test length(saturated.y_vars) == 2
+
         # full nfkb model from benchmarks
         nfkb = @ODEmodel(
             x1'(t) = k_prod - k_deg * x1(t) - k1 * x1(t) * u(t),


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- track the rational-function-field generators locally during output saturation
- add a regression with a rational output whose first Lie derivative is independent

## Root cause

`AbstractAlgebra` 0.50 added an exported `generators` alias, while
`RationalFunctionFields` exports a different `generators` binding. Importing both
leaves the unqualified binding undefined in `StructuralIdentifiability`, so
`saturate_outputs` errors when it calls `generators(current_y)`.

The dependency boundary was reproduced locally:

| RationalFunctionFields | AbstractAlgebra | Nemo | Result |
|---|---|---|---|
| 0.3.1 | 0.48.6 | 0.54.2 | 2 saturated outputs |
| 0.3.3 | 0.49.0 | 0.55.1 | 2 saturated outputs |
| 0.3.3 | 0.50.0 | 0.56.1 | `UndefVarError: generators not defined` |

RationalFunctionFields 0.3.2 widened compatibility to the failing dependency
combination. Rather than relying on its undocumented `generators` helper, this
change retains the exact generator vector already supplied to each field
constructor.

This also fixes the downstream failure exposed by
SciML/ModelingToolkit.jl#4845.

## Local verification

- Julia 1.10, AbstractAlgebra 0.50.1 / Nemo 0.56.1 /
  RationalFunctionFields 0.3.3: focused rational-output regression returns two
  outputs, including `z(t) // a`
- Julia 1.12.6, ModelingToolkit 11.37.1 / ModelingToolkitBase 1.57.1:
  downstream reproduction returns two saturated outputs
- `GROUP=Core julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
- `GROUP=QA julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
  (17 passed, 1 pre-existing broken)
- Runic check on both changed files
