### PR TITLE
Scan ModelingToolkitSIExt in the QA group

### DIFF
--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -4,8 +4,8 @@ using DataStructures
 using Logging
 using Nemo
 using Random
+using RationalFunctionFields: str_to_var, parent_ring_change, eval_at_dict
 using StructuralIdentifiability
-using StructuralIdentifiability: str_to_var, parent_ring_change, eval_at_dict
 using StructuralIdentifiability:
     restart_logging, _si_logger, reset_timings, _to, nonrational_error
 using TimerOutputs
@@ -85,7 +85,7 @@ end
 
 function get_measured_quantities(ode::ModelingToolkitBase.System)
     # filterings is to discard vectorial entities (with tearing and alike)
-    scalar_observed = filter(e -> length(Symbolics.shape(e.rhs)) == 0, ModelingToolkitBase.observed(ode))
+    scalar_observed = filter(e -> length(SymbolicUtils.shape(e.rhs)) == 0, ModelingToolkitBase.observed(ode))
     outputs = filter(
         eq -> ModelingToolkitBase.isoutput(eq.lhs),
         vcat(ModelingToolkitBase.equations(ode), scalar_observed),
@@ -259,8 +259,8 @@ function __mtk_to_si(
         measured_quantities::Array{<:Tuple{String, <:SymbolicUtils.BasicSymbolic}},
     )
 
-    polytype = StructuralIdentifiability.Nemo.QQMPolyRingElem
-    fractype = StructuralIdentifiability.Nemo.Generic.FracFieldElem{polytype}
+    polytype = Nemo.QQMPolyRingElem
+    fractype = Generic.FracFieldElem{polytype}
     diff_eqs = filter(
         eq -> !(ModelingToolkitBase.isoutput(eq.lhs)),
         ModelingToolkitBase.equations(de),

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+StructuralIdentifiability = "220ca800-aa68-49bb-acd8-6037fa93a544"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+ModelingToolkitBase = "1.12"
+SciMLTesting = "2.1"
+SymbolicUtils = "4"
+Symbolics = "7"
+Test = "1"
+julia = "1.10.4, 1.11.2"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,16 @@
 using SciMLTesting, StructuralIdentifiability, Test
 
+# ExplicitImports only walks an extension that is actually loaded (it resolves each
+# `[extensions]` entry through `Base.get_extension`, which is `nothing` otherwise), so
+# every weakdep is loaded here to bring `ModelingToolkitSIExt` into the check.
+using ModelingToolkitBase, SymbolicUtils, Symbolics
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension module actually exists rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(StructuralIdentifiability, :ModelingToolkitSIExt) !== nothing
+end
+
 run_qa(
     StructuralIdentifiability;
     explicit_imports = true,
@@ -23,6 +34,23 @@ run_qa(
                 :enable_progressbar,      # ParamPunPam (non-public)
                 :postwalk,                # MacroTools (non-public)
                 :seed!,                   # Random (non-public)
+                :hasshift,                # ModelingToolkitBase (non-public)
+                # SymbolicUtils (non-public). `Symbolics.scalarize`/`Symbolics.shape`
+                # are public but SymbolicUtils owns both bindings, so the
+                # owner-correct spelling is necessarily the non-public one.
+                :scalarize,
+                :shape,
+                # StructuralIdentifiability's own internals, reached from
+                # ModelingToolkitSIExt. An extension is its own module root, so
+                # ExplicitImports' internal-access allowance does not cover it.
+                :DDS,
+                :_assess_identifiability,
+                :_assess_identifiability_kic,
+                :_assess_local_identifiability,
+                :_assess_local_identifiability_discrete_aux,
+                :_find_identifiable_functions,
+                :_find_identifiable_functions_kic,
+                :x_vars,
             ),
         ),
         all_explicit_imports_are_public = (;
@@ -40,6 +68,13 @@ run_qa(
                 :total_degree_frac,
                 :unpack_fraction,
                 :var_to_str,
+                # StructuralIdentifiability's own internals, imported by
+                # ModelingToolkitSIExt (see the note in the qualified-access list).
+                :_si_logger,
+                :_to,
+                :nonrational_error,
+                :reset_timings,
+                :restart_logging,
             ),
         ),
     ),


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Why

`run_qa` runs ExplicitImports' checks on the package. ExplicitImports *does* know about
extensions — it reads the `[extensions]` table out of `Project.toml` and resolves each
entry through `Base.get_extension` — but an extension module only exists once its trigger
weakdeps are loaded. The QA environment loaded none of them, so `ModelingToolkitSIExt` was
never scanned.

Probe run against the QA environment **as it exists on `master`**:

```
ModelingToolkitSIExt => nothing
SCANNED: StructuralIdentifiability
```

This was a real gap, not incidental coverage: no test dependency pulled
`ModelingToolkitBase`/`SymbolicUtils`/`Symbolics` in transitively.

## What changed

* Added `test/qa/Project.toml`. The QA group had no sub-env before, so it ran in the main
  test target env; the new env carries `ModelingToolkitBase`, `SymbolicUtils` and
  `Symbolics` with `[compat]` bounds mirroring the root `Project.toml`.
* `test/qa/qa.jl` now `using`s the three weakdeps before `run_qa`, and asserts
  `Base.get_extension(StructuralIdentifiability, :ModelingToolkitSIExt) !== nothing` —
  ExplicitImports silently skips an extension that fails to load, so a green `run_qa`
  alone does not prove coverage.

Same probe after the change:

```
ModelingToolkitSIExt => ModelingToolkitSIExt
SCANNED: ModelingToolkitSIExt
SCANNED: StructuralIdentifiability
```

`ModelingToolkitSIExt` is the package's only extension, so extension coverage is now
complete — nothing is left unscanned.

## Extension source fixes (not ignored)

Three findings were genuine and are fixed in `ext/ModelingToolkitSIExt.jl` rather than
ignored:

1. `using StructuralIdentifiability: str_to_var, parent_ring_change, eval_at_dict`
   imported names whose owner is `RationalFunctionFields`
   (`all_explicit_imports_via_owners`). Now imported from `RationalFunctionFields`
   directly, matching what `src/StructuralIdentifiability.jl` already does.
2. `StructuralIdentifiability.Nemo.QQMPolyRingElem` /
   `StructuralIdentifiability.Nemo.Generic.FracFieldElem` reached `Nemo` through
   `StructuralIdentifiability` (`all_qualified_accesses_via_owners`). The extension
   already does `using Nemo`, so these are now `Nemo.QQMPolyRingElem` and
   `Generic.FracFieldElem`, the spelling used throughout `src/`.
3. `Symbolics.shape` is owned by `SymbolicUtils` (`all_qualified_accesses_via_owners`;
   this one only fires on the 1.10 LTS lane). Now `SymbolicUtils.shape` — the two
   bindings are `===`.

## Ignore entries added

`all_qualified_accesses_are_public`:

* `:hasshift` — `ModelingToolkitBase` owns it and has not declared it public; there is no
  public spelling.
* `:scalarize`, `:shape` — owned by `SymbolicUtils`, non-public there. `Symbolics.scalarize`
  and `Symbolics.shape` *are* public, but Symbolics only re-exports the SymbolicUtils
  bindings, so going through Symbolics would just trade this finding for an
  `all_qualified_accesses_via_owners` one. The owner-correct spelling is necessarily the
  non-public one.
* `:DDS`, `:x_vars`, `:_assess_identifiability`, `:_assess_identifiability_kic`,
  `:_assess_local_identifiability`, `:_assess_local_identifiability_discrete_aux`,
  `:_find_identifiable_functions`, `:_find_identifiable_functions_kic` —
  StructuralIdentifiability's *own* internals, reached from its own extension.
  ExplicitImports' `allow_internal_accesses` keys off `Base.moduleroot`, and an extension
  is its own module root, so intra-package access from an extension is still reported.

`all_explicit_imports_are_public`: `:_si_logger`, `:_to`, `:nonrational_error`,
`:reset_timings`, `:restart_logging` — same case as the block above (own internals,
imported by the extension).

No check was disabled and no `@test_broken`/`@test_skip` was added; the pre-existing
`ei_broken = (:no_implicit_imports,)` is unchanged.

## Local runs

Julia 1.12.4:

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Broken  Total     Time
QA/qa.jl      |   20       1     21  1m34.2s
     Testing StructuralIdentifiability tests passed
```

Julia 1.10.11 (the `lts` lane; SciMLTesting skips the two public-API checks there):

```
$ GROUP=QA julia +lts --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Broken  Total   Time
QA/qa.jl      |   18       1     19  44.8s
     Testing StructuralIdentifiability tests passed
```

The extension test group was also run, to confirm the source changes are behavior-neutral:

```
$ GROUP=ModelingToolkitSIExt julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                           | Pass  Total     Time
ModelingToolkitSIExt/modelingtoolkit.jl |   79     79  5m40.0s
     Testing StructuralIdentifiability tests passed
```
