### PR TITLE
Set StructuralIdentifiability version to 0.5.27

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-version = "0.5.26"
+version = "0.5.27"
 authors = ["Alexander Demin, Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 
 [deps]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| StructuralIdentifiability | 0.5.26 | 0.5.26 | 0.5.27 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / QA/qa.jl      |   21     21  2m02.1s / Testing StructuralIdentifiability tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:        | Pass  Total     Time / Core/y_saturation.jl |    9      9  6m07.7s / Test Summary:                           | Pass  Total      Time / ModelingToolkitSIExt/modelingtoolkit.jl |   79     79  16m57.0s / Testing StructuralIdentifiability tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- StructuralIdentifiability: `@JuliaRegistrator register`