### PR TITLE
Drop stale [compat] majors older than one year

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,8 +54,8 @@ SpecialFunctions = "2"
 SymbolicUtils = "4"
 Symbolics = "7"
 Test = "1.10, 1.11"
-TestSetExtensions = "3, 4"
-TimerOutputs = "0.5.10, 1.0"
+TestSetExtensions = "4"
+TimerOutputs = "1.0"
 julia = "1.10.4, 1.11.2"
 
 [extras]


### PR DESCRIPTION
Drop `[compat]` majors whose first General-registry release is older than one year, and keep remaining floors on the latest major.

Policy: SciML minima sit on the latest majors. Extra majors first registered before 2025-08-26 are dropped. Majors first registered after that cutoff are kept (currently: OrdinaryDiffEqCore 4, LinearSolve 4, DiffEqDevTools 3). `julia` and stdlib entries are untouched.

| file | dep | before | after |
|---|---|---|---|
| `Project.toml` | `TestSetExtensions` | `3, 4` | `4` |
| `Project.toml` | `TimerOutputs` | `0.5.10, 1.0` | `1.0` |

OrdinaryDiffEqCore 4 / LinearSolve 4 / DiffEqDevTools 3 are kept where present because they were not in General a year ago.



This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
