### PR TITLE
Fix doctest failure in find_identifiable_functions

### DIFF
--- a/src/identifiable_functions.jl
+++ b/src/identifiable_functions.jl
@@ -30,7 +30,7 @@ This function takes the following optional arguments:
 
 ## Example
 
-```jldoctest
+```jldoctest; setup = :(using Logging; Logging.disable_logging(Logging.Info);)
 using StructuralIdentifiability
   
 ode = @ODEmodel(
@@ -44,8 +44,8 @@ find_identifiable_functions(ode)
 # output
 
 2-element Vector{AbstractAlgebra.Generic.FracFieldElem{Nemo.QQMPolyRingElem}}:
- a12 + a01 + a21
- a12*a01
+ a01 + a12 + a21
+ a01*a12
 ```
 
 """


### PR DESCRIPTION
## Summary

Fixes the failing [Documentation workflow](https://github.com/SciML/StructuralIdentifiability.jl/actions/runs/32653147719) (doctest failure in `src/identifiable_functions.jl:33-49`).

**Root cause:** two independent issues in the `find_identifiable_functions` doctest:

1. The expected output ordered terms as `a12 + a01 + a21` / `a12*a01`, but the currently pinned AbstractAlgebra/Nemo now print multivariate terms in a different (lexicographic-by-name) variable order, producing `a01 + a12 + a21` / `a01*a12`.
2. The doctest was missing the `Logging.disable_logging(Logging.Info)` setup that every neighboring doctest in this file's sibling files (`util.jl`, `parametrizations.jl`, `input_macro.jl`) already uses. `find_identifiable_functions` emits `@info` progress messages by default, which Documenter's doctest runner captures as part of the evaluated output. Since the `# output` block never included those log lines, the doctest would fail on this basis alone, independent of the term-ordering issue above.

## Fix

- Updated the expected `# output` block to match the current term ordering.
- Added `; setup = :(using Logging; Logging.disable_logging(Logging.Info);)` to the ```` ```jldoctest ```` fence, matching the established convention elsewhere in the codebase.

## Test plan

- [x] Ran `julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'` followed by `julia --project=docs docs/make.jl` locally against this branch — the full `makedocs` build (including all doctests) completes successfully with no doctest errors.

Made with [Cursor](https://cursor.com)