### PR TITLE
Relax TimerOutputs compat to fix CI resolution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ SymbolicUtils = "4"
 Symbolics = "7"
 Test = "1.10, 1.11"
 TestSetExtensions = "4"
-TimerOutputs = "1.0"
+TimerOutputs = "0.5.10, 1.0"
 julia = "1.10.4, 1.11.2"
 
 [extras]


### PR DESCRIPTION
## Summary
- CI fails during `Pkg.build` with unsatisfiable `TimerOutputs` requirements: `Groebner` 0.10 needs `TimerOutputs` 0.5.x, but `[compat]` only allowed 1.x.
- Widen the compat bound to `"0.5.10, 1.0"` so the resolver can pick a version compatible with both this package and Groebner.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'` succeeds locally (resolves `TimerOutputs` v0.5.29)
- [ ] CI Tests workflow passes on this PR


Made with [Cursor](https://cursor.com)