### PR TITLE
Format for Runic v1.10

### DIFF
--- a/ext/ModelingToolkitSIExt.jl
+++ b/ext/ModelingToolkitSIExt.jl
@@ -332,13 +332,13 @@ function __mtk_to_si(
     params_from_measured_quantities = union(
         [
             filter(
-                    s ->
-                    !Symbolics.iscall(s) &&
+                s ->
+                !Symbolics.iscall(s) &&
                     !(string(s) in string.(state_vars)) &&
                     !(string(s) * "(t)" in string.(state_vars)) &&
                     (string(s) != string(t)),
-                    get_variables(y[2]),
-                ) for y in measured_quantities
+                get_variables(y[2]),
+            ) for y in measured_quantities
         ]...,
     )
     params = union(params, params_from_measured_quantities)

--- a/src/io_equation.jl
+++ b/src/io_equation.jl
@@ -170,12 +170,12 @@ Output:
         # choosing the output to prolong
         outputs_with_scores = [
             (
-                    min(d[2]...) * length(y_equations[d[1]]),
-                    min(d[2]...),
-                    -count(x -> x == min(d[2]...), d[2]) + length(y_equations[d[1]]) // 30,
-                    length(y_equations[d[1]]),
-                    d[1],
-                ) for d in var_degs
+                min(d[2]...) * length(y_equations[d[1]]),
+                min(d[2]...),
+                -count(x -> x == min(d[2]...), d[2]) + length(y_equations[d[1]]) // 30,
+                length(y_equations[d[1]]),
+                d[1],
+            ) for d in var_degs
         ]
         @debug "Scores: $outputs_with_scores"
         y_prolong = sort(outputs_with_scores)[1][end]

--- a/test/bodies/diff_sequence_solution.jl
+++ b/test/bodies/diff_sequence_solution.jl
@@ -81,9 +81,9 @@ if GROUP == "All" || GROUP == "Core"
             end
             return Dict(
                 (
-                        parent_ring_change(k[1], parent(dds)),
-                        parent_ring_change(k[2], parent(dds)),
-                    ) => res for (k, res) in part_diffs
+                    parent_ring_change(k[1], parent(dds)),
+                    parent_ring_change(k[2], parent(dds)),
+                ) => res for (k, res) in part_diffs
             )
         end
 

--- a/test/bodies/paradigm_shift.jl
+++ b/test/bodies/paradigm_shift.jl
@@ -39,15 +39,15 @@ function test_reparametrization(old_ode, new_ode, var_mapping, implicit_relation
     new_inputs = new_ode.u_vars
     new_param_spec = Dict(
         new_param => StructuralIdentifiability.eval_at_dict(
-                var_mapping[new_param],
-                old_param_spec,
-            ) for new_param in new_params
+            var_mapping[new_param],
+            old_param_spec,
+        ) for new_param in new_params
     )
     new_var_ic = Dict(
         new_var => StructuralIdentifiability.eval_at_dict(
-                var_mapping[new_var],
-                merge(old_param_spec, old_var_ic),
-            ) for new_var in new_vars
+            var_mapping[new_var],
+            merge(old_param_spec, old_var_ic),
+        ) for new_var in new_vars
     )
     new_input_ts = Dict{eltype(new_vars), Vector{Nemo.QQFieldElem}}(
         new_input => old_input_ts[numerator(var_mapping[new_input])] for

--- a/test/bodies/submodels.jl
+++ b/test/bodies/submodels.jl
@@ -145,10 +145,10 @@ include(joinpath(@__DIR__, "..", "shared", "test_setup.jl"))
         submodels = Set(
             [
                 (
-                        collect(map(var_to_str, ode.x_vars)),
-                        collect(map(var_to_str, ode.y_vars)),
-                        collect(map(var_to_str, ode.u_vars)),
-                    ) for ode in submodels
+                    collect(map(var_to_str, ode.x_vars)),
+                    collect(map(var_to_str, ode.y_vars)),
+                    collect(map(var_to_str, ode.u_vars)),
+                ) for ode in submodels
             ]
         )
         @test submodels == c[:submodels]


### PR DESCRIPTION
## What changed and why

Reformat five generator expressions for Runic v1.10.0. Runic v1.10 changed generator-clause indentation, so the previously formatted source no longer passes the repository's formatter check.

This is formatting-only; it makes no behavioral or public-API changes. Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the change, on upstream `17dc385c2e19c64ac7c501bb2941dd7ac91d434b`:

```text
$ julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after the change:

```text
$ julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]

$ git diff --check
[exit 0]

$ typos ext/ModelingToolkitSIExt.jl src/io_equation.jl test/bodies/diff_sequence_solution.jl test/bodies/paradigm_shift.jl test/bodies/submodels.jl
[exit 0]

$ GROUP=QA julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   21     21  11m33.1s
Testing StructuralIdentifiability tests passed

$ GROUP=All julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary:                           | Pass  Total      Time
ModelingToolkitSIExt/modelingtoolkit.jl |   79     79  13m59.6s
Testing StructuralIdentifiability tests passed
```

The first full-suite run reached its one-hour wrapper limit without an assertion or exception. The warm-cache rerun completed successfully with a two-hour wrapper.

## Not verified

No GPU-specific or downstream-package jobs were run beyond the repository's declared `All` group.

## Reviewer note

The diff should contain only Runic's generator indentation changes.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
