### PR TITLE
Fix empty-input Dict{Any,Any} MethodError in wronskian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-version = "0.5.31"
+version = "0.5.32"
 authors = ["Alexander Demin, Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 
 [deps]

--- a/src/wronskian.jl
+++ b/src/wronskian.jl
@@ -215,11 +215,17 @@ Computes the Wronskians of `io_equations`
     ode_red = reduce_ode_mod_p(ode, PRIME)
 
     @debug "Computing power series solution up to order $ord"
+    # Annotate Dict types explicitly: when `u_vars` (or another collection) is
+    # empty, `Dict(k => rand(...) for k in xs)` infers `Dict{Any,Any}` and then
+    # misses the typed `power_series_solution` methods.
+    P_red = eltype(ode_red.x_vars)
     ps = power_series_solution(
         ode_red,
-        Dict(p => rand(1:(PRIME - 1)) for p in ode_red.parameters),
-        Dict(x => rand(1:(PRIME - 1)) for x in ode_red.x_vars),
-        Dict(u => [rand(1:(PRIME - 1)) for i in 0:ord] for u in ode_red.u_vars),
+        Dict{P_red, Int}(p => rand(1:(PRIME - 1)) for p in ode_red.parameters),
+        Dict{P_red, Int}(x => rand(1:(PRIME - 1)) for x in ode_red.x_vars),
+        Dict{P_red, Vector{Int}}(
+            u => [rand(1:(PRIME - 1)) for i in 0:ord] for u in ode_red.u_vars
+        ),
         ord,
     )
 


### PR DESCRIPTION
## Summary
- When an ODE has no inputs, `Dict(u => [rand(...)] for u in ode_red.u_vars)` infers `Dict{Any,Any}` (Julia cannot stabilize the generator when the key iterator is empty and the value uses `rand`).
- That misses the typed `power_series_solution` methods and breaks `assess_identifiability` / `find_identifiable_functions` for input-free models (including all Catalyst extension tests).
- Annotate the three dicts with `P_red = eltype(ode_red.x_vars)`.

## Test plan
- [x] `assess_identifiability` on a Goodwin-like `@ODEmodel` with no inputs succeeds locally after this change (previously `MethodError` on `power_series_solution(..., Dict{Any,Any}, ...)`).
- [ ] SI test suite / Catalyst Extensions Tests go green once released.

Unblocks SciML/Catalyst.jl#1525 Extensions CI.


Made with [Cursor](https://cursor.com)