### PR TITLE
Type the power series input dicts in wronskian (fixes Core tests on TimerOutputs v1)

### DIFF
--- a/src/wronskian.jl
+++ b/src/wronskian.jl
@@ -215,11 +215,16 @@ Computes the Wronskians of `io_equations`
     ode_red = reduce_ode_mod_p(ode, PRIME)
 
     @debug "Computing power series solution up to order $ord"
+    # Element types are spelled out because TimerOutputs v1's `@timeit` boxes the locals
+    # these comprehensions capture; without them an empty `u_vars` yields `Dict{Any, Any}`.
+    Pred = elem_type(polyring_red)
     ps = power_series_solution(
         ode_red,
-        Dict(p => rand(1:(PRIME - 1)) for p in ode_red.parameters),
-        Dict(x => rand(1:(PRIME - 1)) for x in ode_red.x_vars),
-        Dict(u => [rand(1:(PRIME - 1)) for i in 0:ord] for u in ode_red.u_vars),
+        Dict{Pred, Int}(p => rand(1:(PRIME - 1)) for p in ode_red.parameters),
+        Dict{Pred, Int}(x => rand(1:(PRIME - 1)) for x in ode_red.x_vars),
+        Dict{Pred, Vector{Int}}(
+            u => [rand(1:(PRIME - 1)) for i in 0:ord] for u in ode_red.u_vars
+        ),
         ord,
     )
 


### PR DESCRIPTION
Closes #556.

## What changed and why

`wronskian` built the `param_values` / `initial_conditions` / `input_values` arguments of
`power_series_solution` with untyped dict comprehensions. TimerOutputs v1's `@timeit` emits
the wrapped body twice (inside `if enabled … else … end`), and that duplication makes Julia's
closure conversion box the locals those comprehensions capture — so their element types stop
inferring. For any model with no inputs the empty comprehension then produces
`Dict{Any, Any}` and `power_series_solution` has no matching method.

Spelling the element types out fixes the dispatch and is independent of whatever `@timeit`
does to the surrounding scope. Only `src/wronskian.jl` is touched; no behavior change for
models that do have inputs.

Full analysis, standalone TimerOutputs MWE and the registry timeline are in #556.

## Verification

Julia 1.12.7, environment resolved with `Pkg.update()` (picks `TimerOutputs v1.2.1`,
`RationalFunctionFields v0.3.5`), ModelingToolkit master `Pkg.develop`ed in exactly as
`ModelingToolkit.jl/.github/workflows/Downstream.yml` does.

### Failing before the fix

`GROUP=Core julia +1.12 --project=StructuralIdentifiability.jl -e 'using Pkg; Pkg.test()'`
on unmodified master (`90f8452a61109fe29e434d604bd22ad80d474fdd`):

```
Assessing identifiability: Error During Test at test/bodies/identifiability.jl:3
  Got exception outside of a @test
  MethodError: no method matching power_series_solution(::ODE{Nemo.fpMPolyRingElem}, ::Dict{Nemo.fpMPolyRingElem, Int64}, ::Dict{Nemo.fpMPolyRingElem, Int64}, ::Dict{Any, Any}, ::Int64)

  Closest candidates are:
    power_series_solution(::ODE{P}, ::Dict{P, Int64}, ::Dict{P, Int64}, !Matched::Dict{P, Vector{Int64}}, ::Int64) where P<:(MPolyRingElem{<:FieldElem})
     @ StructuralIdentifiability src/ODE.jl:202
    ...
  Stacktrace:
    [1] wronskian(io_equations::Dict{QQMPolyRingElem, QQMPolyRingElem}, ode::ODE{QQMPolyRingElem})
        @ StructuralIdentifiability src/wronskian.jl:218

Test Summary:                 | Error  Total   Time
Core/identifiability.jl       |     1      1  35.5s
ERROR: Package StructuralIdentifiability errored during testing
```

The group aborts there, so nothing after `identifiability.jl` runs at all.

### Passing after the fix

Same command, same environment, with this branch:

```
Core/identifiability.jl |   11     11  2m13.7s
Core/identifiable_functions.jl |  800    800  37m14.5s
Core/io_cases.jl |    6      6  0.4s
...
Core/y_saturation.jl |    9      9  4m14.2s
     Testing StructuralIdentifiability tests passed
```

All 39 `Core` files pass; every one of them is new coverage relative to the current master
run, which never got past `identifiability.jl`.

### QA

```
GROUP=QA julia +1.12 --project=StructuralIdentifiability.jl -e 'using Pkg; Pkg.test()'

Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  1m36.9s
     Testing StructuralIdentifiability tests passed
```

### Formatting / spelling

`Runic.main(["--check", "src/wronskian.jl"])` → exit 0. `typos src/wronskian.jl` → clean.

## What I did not verify

- The `Downgrade` and 32-bit (`Core 32-bit`) lanes — not run locally.
- The `ModelingToolkitSIExt` group — not run locally (it precompiled cleanly during the QA run).
- The docs build — this PR touches no docstring, `docs/`, or public API.

## Note for the reviewer

The underlying defect is in TimerOutputs v1's `@timeit`, not here; this is a targeted
workaround at the one call site whose dispatch depends on the dict type. The `Core.Box`
that `@timeit` introduces is present in **every** `@timeit`-annotated function in `src/`
and is silently costing inference elsewhere, so an upstream fix is still worth chasing —
see #556 for the standalone MWE to file with TimerOutputs.jl.

The alternative fix would be to cap `TimerOutputs = "0.5.10"` again, but #548 relaxed that
deliberately to resolve a Groebner conflict, so re-capping would reintroduce it.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_01GdSpCLd7NBZuuePJmcDzU7
