### PR TITLE
Release StructuralIdentifiability 0.5.32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuralIdentifiability"
 uuid = "220ca800-aa68-49bb-acd8-6037fa93a544"
-version = "0.5.31"
+version = "0.5.32"
 authors = ["Alexander Demin, Ruiwen Dong, Christian Goodbrake, Heather Harrington, Gleb Pogudin <gleb.pogudin@polytechnique.edu>"]
 
 [deps]


### PR DESCRIPTION
Bumps `StructuralIdentifiability` 0.5.31 -> 0.5.32 (patch).

Source files changed since 0.5.31:
- `src/ODE.jl`
- `src/discrete.jl`
- `src/lincomp.jl`
- `src/power_series_utils.jl`

Commits:
- Update documentation links in README.md
- Add 32-bit Core CI lane via test_groups.toml (#554)
- Accept Int64 dict values in power_series_solution on 32-bit (#555)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
