### PR TITLE
Fix reusable workflow ref: grouped-tests.yml@v1

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    uses: "SciML/.github/.github/workflows/grouped-tests.yml@1"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

`Tests.yml` references `SciML/.github/.github/workflows/grouped-tests.yml@1`, but the `SciML/.github` repo only publishes the tag `v1` (there is no `1` ref). The unresolvable ref makes the workflow fail at parse time — the latest master run (`Release StructuralIdentifiability 0.5.32`) failed with **zero jobs created**.

Every other workflow in this repo already uses `@v1`; this aligns Tests.yml.

#### Test plan
- [x] Confirmed `refs/tags/v1` exists in SciML/.github and no `1` ref exists
- [x] All other workflows in this repo use `@v1` for the same reusable workflows

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL